### PR TITLE
[Feat] 회원 정보 조회, 수정 기능 구현

### DIFF
--- a/src/main/java/com/manchui/domain/controller/UserController.java
+++ b/src/main/java/com/manchui/domain/controller/UserController.java
@@ -1,9 +1,50 @@
 package com.manchui.domain.controller;
 
-import org.springframework.stereotype.Controller;
+import com.manchui.domain.dto.CustomUserDetails;
+import com.manchui.domain.dto.User.UserEditInfoResponse;
+import com.manchui.domain.dto.User.UserEditInfoRequest;
+import com.manchui.domain.dto.User.UserInfoResponse;
+import com.manchui.domain.entity.User;
+import com.manchui.domain.service.UserService;
+import com.manchui.global.response.SuccessResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
 
-@Controller
+import java.util.UUID;
+
+@RestController
+@RequiredArgsConstructor
 public class UserController {
 
+    private final UserService userService;
+
+    @GetMapping("/api/auths/user")
+    public ResponseEntity<SuccessResponse<UserInfoResponse>> userInfo(@AuthenticationPrincipal CustomUserDetails userDetails) {
+
+        String userEmail = userDetails.getUsername();
+        UserInfoResponse userInfo = userService.getUserInfo(userEmail);
+
+        return ResponseEntity.ok().body(SuccessResponse.successWithData(userInfo));
+    }
+
+    @PutMapping("/api/auths/user")
+    public ResponseEntity<SuccessResponse<UserEditInfoResponse>> editUserInfo(@AuthenticationPrincipal CustomUserDetails userDetails,
+                                                          @ModelAttribute @Valid UserEditInfoRequest userEditInfoRequest) {
+
+        String userEmail = userDetails.getUsername();
+        userService.checkName(userEditInfoRequest.getName());
+        UUID userId = userService.editUserInfo(userEmail, userEditInfoRequest);
+        User user = userService.findByUserId(userId);
+        UserEditInfoResponse response = UserEditInfoResponse.builder()
+                .id(userId)
+                .name(user.getName())
+                .profileImagePath(user.getProfileImagePath())
+                .build();
+
+        return ResponseEntity.ok().body(SuccessResponse.successWithData(response));
+    }
 
 }

--- a/src/main/java/com/manchui/domain/dto/User/UserEditInfoRequest.java
+++ b/src/main/java/com/manchui/domain/dto/User/UserEditInfoRequest.java
@@ -1,0 +1,16 @@
+package com.manchui.domain.dto.User;
+
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.web.multipart.MultipartFile;
+
+@Getter
+@Setter
+public class UserEditInfoRequest {
+
+    @Size(min = 2, max = 40, message = "이름은 최소 2자, 최대 40자여야 합니다.")
+    private String name;
+    private MultipartFile image;
+}

--- a/src/main/java/com/manchui/domain/dto/User/UserEditInfoResponse.java
+++ b/src/main/java/com/manchui/domain/dto/User/UserEditInfoResponse.java
@@ -1,0 +1,17 @@
+package com.manchui.domain.dto.User;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.UUID;
+
+@Getter
+@Setter
+@Builder
+public class UserEditInfoResponse {
+
+    private UUID id;
+    private String name;
+    private String profileImagePath;
+}

--- a/src/main/java/com/manchui/domain/dto/User/UserInfoResponse.java
+++ b/src/main/java/com/manchui/domain/dto/User/UserInfoResponse.java
@@ -1,0 +1,18 @@
+package com.manchui.domain.dto.User;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.UUID;
+
+@Getter
+@Setter
+@Builder
+public class UserInfoResponse {
+
+    private UUID id;
+    private String email;
+    private String name;
+    private String image;
+}

--- a/src/main/java/com/manchui/domain/entity/User.java
+++ b/src/main/java/com/manchui/domain/entity/User.java
@@ -34,4 +34,12 @@ public class User extends Timestamped {
         this.email = email;
         this.password = password;
     }
+
+    public void editName(String name) {
+        this.name = name;
+    }
+
+    public void editProfileImagePath(String filePath) {
+        this.profileImagePath = filePath;
+    }
 }

--- a/src/main/java/com/manchui/domain/repository/UserRepository.java
+++ b/src/main/java/com/manchui/domain/repository/UserRepository.java
@@ -4,8 +4,10 @@ import com.manchui.domain.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.UUID;
+
 @Repository
-public interface UserRepository extends JpaRepository<User, Long> {
+public interface UserRepository extends JpaRepository<User, UUID> {
 
     Boolean existsByName(String name);
 

--- a/src/main/java/com/manchui/domain/service/ImageServiceImpl.java
+++ b/src/main/java/com/manchui/domain/service/ImageServiceImpl.java
@@ -31,6 +31,11 @@ public class ImageServiceImpl {
 
     }
 
+    public Long uploadUserProfileImage(MultipartFile multipartFile) {
+        return imageRepository.save(toImageEntity(multipartFile, null)).getImageId();
+    }
+
+
     // MultipartFile 을 Image Entity 형태로 변경
     public Image toImageEntity(MultipartFile multipartFile, Long gatheringId) {
 
@@ -39,6 +44,10 @@ public class ImageServiceImpl {
         String fakeFileName = createRandomFileName(multipartFile.getOriginalFilename());
         String originalFileName = multipartFile.getOriginalFilename();
         String filePath = s3Uploader.uploadImage(multipartFile, fakeFileName);
+
+        if(gatheringId == null){
+            return new Image(originalFileName, fakeFileName, filePath);
+        }
 
         return new Image(originalFileName, fakeFileName,  filePath, gatheringId);
 

--- a/src/main/java/com/manchui/domain/service/UserService.java
+++ b/src/main/java/com/manchui/domain/service/UserService.java
@@ -1,18 +1,28 @@
 package com.manchui.domain.service;
 
+import com.manchui.domain.dto.User.UserEditInfoRequest;
+import com.manchui.domain.dto.User.UserInfoResponse;
+import com.manchui.domain.entity.Image;
 import com.manchui.domain.entity.User;
+import com.manchui.domain.repository.ImageRepository;
 import com.manchui.domain.repository.UserRepository;
 import com.manchui.global.exception.CustomException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
-import static com.manchui.global.exception.ErrorCode.USER_NOT_FOUND;
+import java.util.UUID;
+
+import static com.manchui.global.exception.ErrorCode.*;
 
 @Service
 @RequiredArgsConstructor
 public class UserService {
 
     private final UserRepository userRepository;
+    private final ImageServiceImpl imageService;
+    private final ImageRepository imageRepository;
 
     // 유저 객체 검증
     public User checkUser(String email) {
@@ -25,4 +35,44 @@ public class UserService {
         return user;
     }
 
+    //유저 정보 반환
+    public UserInfoResponse getUserInfo(String userEmail) {
+        User user = userRepository.findByEmail(userEmail);
+
+        return UserInfoResponse.builder()
+                .id(user.getId())
+                .email(user.getEmail())
+                .name(user.getName())
+                .image(user.getProfileImagePath())
+                .build();
+    }
+
+    //유저 정보 수정
+    @Transactional
+    public UUID editUserInfo(String userEmail, UserEditInfoRequest userEditInfoRequest) {
+
+        User user = userRepository.findByEmail(userEmail);
+        MultipartFile image = userEditInfoRequest.getImage();
+        String name = userEditInfoRequest.getName();
+        Long imageId = imageService.uploadUserProfileImage(image);
+        user.editName(name);
+        Image findImage = imageRepository.findById(imageId)
+                .orElseThrow(() -> new CustomException(IMAGE_NOT_FOUND));
+        String filePath = findImage.getFilePath();
+        user.editProfileImagePath(filePath);
+        return user.getId();
+    }
+
+    //유저 조회
+    public User findByUserId(UUID userId) {
+
+        return userRepository.findById(userId).orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+    }
+
+    //유저 이름 중복 확인
+    public void checkName(String name) {
+        if (userRepository.existsByName(name)) {
+            throw new CustomException(ILLEGAL_USERNAME_DUPLICATION);
+        }
+    }
 }

--- a/src/main/java/com/manchui/global/exception/ErrorCode.java
+++ b/src/main/java/com/manchui/global/exception/ErrorCode.java
@@ -31,13 +31,14 @@ public enum ErrorCode {
     ALREADY_JOIN_GATHERING(HttpStatus.BAD_REQUEST, "이미 참여 신청된 모임입니다."),
     ALREADY_HEART_GATHERING(HttpStatus.BAD_REQUEST, "이미 좋아요를 누른 모임입니다."),
     ATTENDANCE_NOT_EXIST(HttpStatus.BAD_REQUEST, "참여한 모임만 취소 가능합니다."),
-    ALREADY_HEART_GATHERING(HttpStatus.BAD_REQUEST, "이미 좋아요를 누른 모임입니다."),
 
 
     // image
     ILLEGAL_EMPTY_FILE(HttpStatus.BAD_REQUEST, "이미지 파일은 필수 입력 값입니다."),
     WRONG_TYPE_IMAGE(HttpStatus.BAD_REQUEST, "유효하지 않은 이미지 파일형식 입니다."),
-    FAILED_UPLOAD_IMAGE(HttpStatus.BAD_REQUEST, "이미지 업로드에 실패했습니다.");
+    FAILED_UPLOAD_IMAGE(HttpStatus.BAD_REQUEST, "이미지 업로드에 실패했습니다."),
+    IMAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "이미지를 찾을수 없습니다.");
+
 
     private final HttpStatus httpStatus;
     private final String message;


### PR DESCRIPTION
## #️⃣ Issue Number

<!--- ex) #이슈번호, #이슈번호 -->
#19 

## 📝 요약(Summary)

<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
- 회원 정보 조회 및 수정 구현 
- 회원의 이름, 이메일, 사진을 조회 가능하거나 이름과 사진을 수정 가능하도록 하였습니다.
- 이름 수정시 최소 2자, 최대 40자 제한, 이미지 파일은 필수
  - 위 조건에 부합하지 않은경우 예외 반환

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [X] 회원 정보 조회 기능 추가
- [X] 회원 정보 수정 기능 추가
