### PR TITLE
[Feat] 찜한 모임 목록 조회 기능 구현

### DIFF
--- a/src/main/java/com/manchui/domain/controller/GatheringController.java
+++ b/src/main/java/com/manchui/domain/controller/GatheringController.java
@@ -150,12 +150,36 @@ public class GatheringController {
         return ResponseEntity.ok(SuccessResponse.successWithData(gatheringService.getGatheringInfoByUser(userDetails.getUsername(), gatheringId)));
     }
 
+    @Operation(summary = "찜한 모임 목록 조회", description = "회원이 찜한 모임 목록을 반환합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "회원의 찜한 모임 목록입니다.",
+                    content = @Content(mediaType = "application/json")),
+            @ApiResponse(responseCode = "404", description = "찜한 모임이 없습니다.")
+    })
     @PatchMapping("/{gatheringId}/cancel")
     public ResponseEntity<SuccessResponse<String>> cancelGathering(@AuthenticationPrincipal CustomUserDetails userDetails,
                                                                    @PathVariable Long gatheringId) {
 
         gatheringService.cancelGathering(userDetails.getUsername(), gatheringId);
         return ResponseEntity.ok(SuccessResponse.successWithNoData("모임이 정상적으로 취소되었습니다."));
+    }
+
+    @Operation(summary = "찜한 모임 목록 조회", description = "회원이 찜한 모임 목록을 반환합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "회원의 찜한 모임 목록입니다.",
+                    content = @Content(mediaType = "application/json")),
+            @ApiResponse(responseCode = "404", description = "찜한 모임이 없습니다.")
+    })
+    @GetMapping("/heart")
+    public ResponseEntity<SuccessResponse<GatheringPagingResponse>> getHeartList(@AuthenticationPrincipal CustomUserDetails userDetails,
+                                                                                 @PageableDefault Pageable pageable,
+                                                                                 @RequestParam(required = false) String location,
+                                                                                 @RequestParam(required = false) String startDate,
+                                                                                 @RequestParam(required = false) String endDate,
+                                                                                 @RequestParam(required = false) String category,
+                                                                                 @RequestParam(required = false) String sort) {
+
+        return ResponseEntity.ok(SuccessResponse.successWithData(gatheringService.getHeartList(userDetails.getUsername(), pageable, location, startDate, endDate, category, sort)));
     }
 
 }

--- a/src/main/java/com/manchui/domain/repository/querydsl/GatheringQueryDsl.java
+++ b/src/main/java/com/manchui/domain/repository/querydsl/GatheringQueryDsl.java
@@ -10,4 +10,6 @@ public interface GatheringQueryDsl {
 
     Page<GatheringListResponse> getGatheringListByUser(String email, Pageable pageable, String query, String location, String startDate, String endDate, String category, String sort);
 
+    Page<GatheringListResponse> getHeartList(String email, Pageable pageable, String location, String startDate, String endDate, String category, String sort);
+
 }

--- a/src/main/java/com/manchui/domain/service/GatheringService.java
+++ b/src/main/java/com/manchui/domain/service/GatheringService.java
@@ -28,4 +28,6 @@ public interface GatheringService {
 
     void cancelGathering(String email, Long gatheringId);
 
+    GatheringPagingResponse getHeartList(String email, Pageable pageable, String location, String startDate, String endDate, String category, String sort);
+
 }

--- a/src/main/java/com/manchui/domain/service/GatheringServiceImpl.java
+++ b/src/main/java/com/manchui/domain/service/GatheringServiceImpl.java
@@ -259,6 +259,26 @@ public class GatheringServiceImpl implements GatheringService {
         gathering.cancel();
     }
 
+    /**
+     * 6. 찜한 모임 목록 조회
+     * 작성자: 오예령
+     *
+     * @param email     유저 email
+     * @param pageable  페이징 처리에 필요한 데이터
+     * @param location  위치
+     * @param startDate 시작 날짜
+     * @param endDate   끝 날짜
+     * @param category  모임 카테고리
+     * @param sort      정렬 기준
+     * @return 유저가 찜한 모임의 목록 반환
+     */
+    @Override
+    @Transactional
+    public GatheringPagingResponse getHeartList(String email, Pageable pageable, String location, String startDate, String endDate, String category, String sort) {
+
+        return new GatheringPagingResponse(gatheringRepository.getHeartList(email, pageable, location, startDate, endDate, category, sort));
+    }
+
     // 참여 여부 판단
     private void handleExistingAttendance(Attendance attendance) {
 


### PR DESCRIPTION
## #️⃣ Issue Number

<!--- ex) #이슈번호, #이슈번호 -->
#36 

## 📝 요약(Summary)

<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
- 회원이 찜한 모임 목록 조회 기능을 구현하였습니다.
- Figma를 기반으로 모임 목록 조회와 동일하게 필터링 처리하였고, 검색 기능은 제외하였습니다.
- 프론트엔드와 모임 목록 조회 API 통신 시에 마감 날짜 순으로 조회하니 Closed 된 모임부터 보여지게 되어 closed된 모임 또한 목록 반환 형태 내에서 제외시키도록 수정하였습니다.

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [X] 새로운 기능 추가
- [X] 코드 리팩토링

