### PR TITLE
[Feat] 사용자가 작성한 모임 목록 조회 기능 구현

### DIFF
--- a/src/main/java/com/manchui/domain/controller/UserController.java
+++ b/src/main/java/com/manchui/domain/controller/UserController.java
@@ -4,11 +4,15 @@ import com.manchui.domain.dto.CustomUserDetails;
 import com.manchui.domain.dto.User.UserEditInfoResponse;
 import com.manchui.domain.dto.User.UserEditInfoRequest;
 import com.manchui.domain.dto.User.UserInfoResponse;
+import com.manchui.domain.dto.User.UserWrittenGatheringsResponse;
 import com.manchui.domain.entity.User;
 import com.manchui.domain.service.UserService;
 import com.manchui.global.response.SuccessResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -45,6 +49,16 @@ public class UserController {
                 .build();
 
         return ResponseEntity.ok().body(SuccessResponse.successWithData(response));
+    }
+
+    @GetMapping("/api/users/gatherings")
+    public ResponseEntity<SuccessResponse<UserWrittenGatheringsResponse>> getMyGatheringList(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PageableDefault(size = 10, sort = "gatheringDate", direction = Sort.Direction.DESC) Pageable pageable) {
+
+        UserWrittenGatheringsResponse response = userService.getWrittenGatheringList(userDetails.getUsername(), pageable);
+
+        return ResponseEntity.ok(SuccessResponse.successWithData(response));
     }
 
 }

--- a/src/main/java/com/manchui/domain/dto/User/UserWrittenGatheringsResponse.java
+++ b/src/main/java/com/manchui/domain/dto/User/UserWrittenGatheringsResponse.java
@@ -1,0 +1,26 @@
+package com.manchui.domain.dto.User;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+
+@Getter
+@Setter
+public class UserWrittenGatheringsResponse {
+
+    private long gatheringCount;
+    private Page<WrittenGathering> writtenGatheringList;
+    private long pageSize;
+    private long page;
+    private long totalPage;
+
+    public UserWrittenGatheringsResponse(long gatheringCount, Page<WrittenGathering> writtenGatheringList, long pageSize, long page, long totalPage) {
+        this.gatheringCount = gatheringCount;
+        this.writtenGatheringList = writtenGatheringList;
+        this.pageSize = pageSize;
+        this.page = page;
+        this.totalPage = totalPage;
+    }
+}

--- a/src/main/java/com/manchui/domain/dto/User/WrittenGathering.java
+++ b/src/main/java/com/manchui/domain/dto/User/WrittenGathering.java
@@ -1,0 +1,47 @@
+package com.manchui.domain.dto.User;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+public class WrittenGathering {
+    private Long gatheringId;
+    private String groupName;
+    private String category;
+    private String location;
+    private String gatheringImage;
+    private LocalDateTime gatheringDate;
+    private LocalDateTime dueDate;
+    private int maxUsers;
+    private int participantUsers;
+    private Boolean isOpened;
+    private Boolean isCanceled;
+    private Boolean isClosed;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+    private LocalDateTime deletedAt;
+
+    public WrittenGathering(Long gatheringId, String groupName, String category, String location, String gatheringImage
+                            , LocalDateTime gatheringDate, LocalDateTime dueDate, int maxUsers, int participantUsers
+                            , Boolean isOpened, Boolean isCanceled, Boolean isClosed, LocalDateTime createdAt
+                            , LocalDateTime updatedAt, LocalDateTime deletedAt) {
+        this.gatheringId = gatheringId;
+        this.groupName = groupName;
+        this.category = category;
+        this.location = location;
+        this.gatheringImage = gatheringImage;
+        this.gatheringDate = gatheringDate;
+        this.dueDate = dueDate;
+        this.maxUsers = maxUsers;
+        this.participantUsers = participantUsers;
+        this.isOpened = isOpened;
+        this.isCanceled = isCanceled;
+        this.isClosed = isClosed;
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+        this.deletedAt = deletedAt;
+    }
+}

--- a/src/main/java/com/manchui/domain/repository/GatheringRepository.java
+++ b/src/main/java/com/manchui/domain/repository/GatheringRepository.java
@@ -1,8 +1,13 @@
 package com.manchui.domain.repository;
 
 import com.manchui.domain.entity.Gathering;
+import com.manchui.domain.entity.User;
 import com.manchui.domain.repository.querydsl.GatheringQueryDsl;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface GatheringRepository extends JpaRepository<Gathering, Long>, GatheringQueryDsl {
+
+    Page<Gathering> findByUserEquals(User user, Pageable pageable);
 }

--- a/src/main/java/com/manchui/domain/service/UserService.java
+++ b/src/main/java/com/manchui/domain/service/UserService.java
@@ -1,13 +1,23 @@
 package com.manchui.domain.service;
 
+import com.manchui.domain.dto.GatheringListResponse;
 import com.manchui.domain.dto.User.UserEditInfoRequest;
 import com.manchui.domain.dto.User.UserInfoResponse;
+import com.manchui.domain.dto.User.UserWrittenGatheringsResponse;
+import com.manchui.domain.dto.User.WrittenGathering;
+import com.manchui.domain.entity.Gathering;
 import com.manchui.domain.entity.Image;
 import com.manchui.domain.entity.User;
+import com.manchui.domain.repository.AttendanceRepository;
+import com.manchui.domain.repository.GatheringRepository;
 import com.manchui.domain.repository.ImageRepository;
 import com.manchui.domain.repository.UserRepository;
 import com.manchui.global.exception.CustomException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.security.core.parameters.P;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -23,6 +33,8 @@ public class UserService {
     private final UserRepository userRepository;
     private final ImageServiceImpl imageService;
     private final ImageRepository imageRepository;
+    private final GatheringRepository gatheringRepository;
+    private final AttendanceRepository attendanceRepository;
 
     // 유저 객체 검증
     public User checkUser(String email) {
@@ -75,5 +87,29 @@ public class UserService {
         if (userRepository.existsByName(name)) {
             throw new CustomException(ILLEGAL_USERNAME_DUPLICATION);
         }
+    }
+
+    //내가 작성한 모임 목록 조회
+    public UserWrittenGatheringsResponse getWrittenGatheringList(String userEmail, Pageable pageable) {
+
+        User user = userRepository.findByEmail(userEmail);
+
+        Page<Gathering> gatheringList = gatheringRepository.findByUserEquals(user, pageable);
+
+        //DTO에 맞게 변환
+        Page<WrittenGathering> writtenGatheringList = gatheringList.map(m -> {
+            String imagePath = imageRepository.findByGatheringId(m.getId()).getFilePath();
+            int participantUsers = attendanceRepository.countByGatheringAndDeletedAtIsNull(m);
+
+            return new WrittenGathering(m.getId(), m.getGroupName(), m.getCategory(), m.getLocation(),
+                    imagePath, m.getGatheringDate(), m.getDueDate(),
+                    m.getMaxUsers(), participantUsers, m.isOpened(), m.isCanceled(), m.isClosed(), m.getCreatedAt(),
+                    m.getUpdatedAt(), m.getDeletedAt());
+        });
+
+        return new UserWrittenGatheringsResponse(
+                writtenGatheringList.getNumberOfElements(), writtenGatheringList,
+                writtenGatheringList.getSize(), writtenGatheringList.getNumber(),
+                writtenGatheringList.getTotalPages());
     }
 }


### PR DESCRIPTION
## #️⃣ Issue Number

<!--- ex) #이슈번호, #이슈번호 -->
#43 

## 📝 요약(Summary)

<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
 - 사용자가 작성한 모임 목록 조회 기능 구현
   - accessToken 검증이 완료되면 파라미터로 전달받은 page, size를 가지고 사용자가 작성한 모임 목록 조회에 필요한 데이터를 반환한다.

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [X] 새로운 기능 추가
