### PR TITLE
[Feat] 후기 삭제 기능 구현

### DIFF
--- a/src/main/java/com/manchui/domain/controller/GatheringController.java
+++ b/src/main/java/com/manchui/domain/controller/GatheringController.java
@@ -1,6 +1,10 @@
 package com.manchui.domain.controller;
 
 import com.manchui.domain.dto.*;
+import com.manchui.domain.dto.gathering.GatheringCreateRequest;
+import com.manchui.domain.dto.gathering.GatheringCreateResponse;
+import com.manchui.domain.dto.gathering.GatheringInfoResponse;
+import com.manchui.domain.dto.gathering.GatheringPagingResponse;
 import com.manchui.domain.service.GatheringService;
 import com.manchui.global.response.SuccessResponse;
 import io.swagger.v3.oas.annotations.Operation;

--- a/src/main/java/com/manchui/domain/controller/ReviewController.java
+++ b/src/main/java/com/manchui/domain/controller/ReviewController.java
@@ -1,7 +1,8 @@
 package com.manchui.domain.controller;
 
 import com.manchui.domain.dto.CustomUserDetails;
-import com.manchui.domain.dto.ReviewCreateResponse;
+import com.manchui.domain.dto.review.ReviewCreateRequest;
+import com.manchui.domain.dto.review.ReviewCreateResponse;
 import com.manchui.domain.service.ReviewService;
 import com.manchui.global.response.SuccessResponse;
 import jakarta.validation.Valid;
@@ -19,9 +20,17 @@ public class ReviewController {
 
     @PostMapping("/{gatheringId}")
     public ResponseEntity<SuccessResponse<ReviewCreateResponse>> createReview(@AuthenticationPrincipal CustomUserDetails userDetails, @PathVariable Long gatheringId,
-                                                                              @Valid @RequestBody ReviewCreateResponse createResponse) {
+                                                                              @Valid @RequestBody ReviewCreateRequest createRequest) {
 
-        return ResponseEntity.status(201).body(SuccessResponse.successWithData(reviewService.createReview(userDetails.getUsername(), gatheringId, createResponse)));
+        return ResponseEntity.status(201).body(SuccessResponse.successWithData(reviewService.createReview(userDetails.getUsername(), gatheringId, createRequest)));
     }
+
+    @PutMapping("/{reviewId}")
+    public ResponseEntity<SuccessResponse<ReviewCreateResponse>> updateReview(@AuthenticationPrincipal CustomUserDetails userDetails, @PathVariable Long reviewId,
+                                                                              @Valid @RequestBody ReviewCreateRequest updateRequest) {
+
+        return ResponseEntity.ok().body(SuccessResponse.successWithData(reviewService.updateReview(userDetails.getUsername(), reviewId, updateRequest)));
+    }
+
 
 }

--- a/src/main/java/com/manchui/domain/controller/ReviewController.java
+++ b/src/main/java/com/manchui/domain/controller/ReviewController.java
@@ -32,5 +32,11 @@ public class ReviewController {
         return ResponseEntity.ok().body(SuccessResponse.successWithData(reviewService.updateReview(userDetails.getUsername(), reviewId, updateRequest)));
     }
 
+    @DeleteMapping("/{reviewId}")
+    public ResponseEntity<SuccessResponse<ReviewCreateResponse>> deleteReview(@AuthenticationPrincipal CustomUserDetails userDetails, @PathVariable Long reviewId) {
+
+        reviewService.deleteReview(userDetails.getUsername(), reviewId);
+        return ResponseEntity.ok().body(SuccessResponse.successWithNoData("후기가 정상적으로 삭제되었습니다."));
+    }
 
 }

--- a/src/main/java/com/manchui/domain/dto/gathering/GatheringCreateRequest.java
+++ b/src/main/java/com/manchui/domain/dto/gathering/GatheringCreateRequest.java
@@ -1,4 +1,4 @@
-package com.manchui.domain.dto;
+package com.manchui.domain.dto.gathering;
 
 import com.manchui.domain.entity.Gathering;
 import com.manchui.domain.entity.User;

--- a/src/main/java/com/manchui/domain/dto/gathering/GatheringCreateResponse.java
+++ b/src/main/java/com/manchui/domain/dto/gathering/GatheringCreateResponse.java
@@ -1,4 +1,4 @@
-package com.manchui.domain.dto;
+package com.manchui.domain.dto.gathering;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -46,4 +46,5 @@ public class GatheringCreateResponse {
     private LocalDateTime deletedAt;
 
     private boolean isHearted;
+
 }

--- a/src/main/java/com/manchui/domain/dto/gathering/GatheringInfoResponse.java
+++ b/src/main/java/com/manchui/domain/dto/gathering/GatheringInfoResponse.java
@@ -1,5 +1,7 @@
-package com.manchui.domain.dto;
+package com.manchui.domain.dto.gathering;
 
+import com.manchui.domain.dto.review.ReviewInfo;
+import com.manchui.domain.dto.UserInfo;
 import com.manchui.domain.entity.Gathering;
 import lombok.AllArgsConstructor;
 import lombok.Getter;

--- a/src/main/java/com/manchui/domain/dto/gathering/GatheringListResponse.java
+++ b/src/main/java/com/manchui/domain/dto/gathering/GatheringListResponse.java
@@ -1,4 +1,4 @@
-package com.manchui.domain.dto;
+package com.manchui.domain.dto.gathering;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;

--- a/src/main/java/com/manchui/domain/dto/gathering/GatheringPagingResponse.java
+++ b/src/main/java/com/manchui/domain/dto/gathering/GatheringPagingResponse.java
@@ -1,4 +1,4 @@
-package com.manchui.domain.dto;
+package com.manchui.domain.dto.gathering;
 
 import lombok.Getter;
 import lombok.NoArgsConstructor;

--- a/src/main/java/com/manchui/domain/dto/review/ReviewCreateRequest.java
+++ b/src/main/java/com/manchui/domain/dto/review/ReviewCreateRequest.java
@@ -1,4 +1,4 @@
-package com.manchui.domain.dto;
+package com.manchui.domain.dto.review;
 
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;

--- a/src/main/java/com/manchui/domain/dto/review/ReviewCreateResponse.java
+++ b/src/main/java/com/manchui/domain/dto/review/ReviewCreateResponse.java
@@ -1,4 +1,4 @@
-package com.manchui.domain.dto;
+package com.manchui.domain.dto.review;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/src/main/java/com/manchui/domain/dto/review/ReviewInfo.java
+++ b/src/main/java/com/manchui/domain/dto/review/ReviewInfo.java
@@ -1,4 +1,4 @@
-package com.manchui.domain.dto;
+package com.manchui.domain.dto.review;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;

--- a/src/main/java/com/manchui/domain/dto/review/ReviewPagingResponse.java
+++ b/src/main/java/com/manchui/domain/dto/review/ReviewPagingResponse.java
@@ -1,4 +1,4 @@
-package com.manchui.domain.dto;
+package com.manchui.domain.dto.review;
 
 import lombok.Getter;
 import lombok.NoArgsConstructor;

--- a/src/main/java/com/manchui/domain/entity/Gathering.java
+++ b/src/main/java/com/manchui/domain/entity/Gathering.java
@@ -1,6 +1,6 @@
 package com.manchui.domain.entity;
 
-import com.manchui.domain.dto.GatheringCreateResponse;
+import com.manchui.domain.dto.gathering.GatheringCreateResponse;
 import com.manchui.global.entity.Timestamped;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.Max;

--- a/src/main/java/com/manchui/domain/entity/Review.java
+++ b/src/main/java/com/manchui/domain/entity/Review.java
@@ -1,6 +1,7 @@
 package com.manchui.domain.entity;
 
-import com.manchui.domain.dto.ReviewCreateResponse;
+import com.manchui.domain.dto.review.ReviewCreateRequest;
+import com.manchui.domain.dto.review.ReviewCreateResponse;
 import com.manchui.global.entity.Timestamped;
 import jakarta.persistence.*;
 import lombok.*;
@@ -44,6 +45,14 @@ public class Review extends Timestamped {
                 .score(score)
                 .comment(comment)
                 .build();
+    }
+
+    public void update(ReviewCreateRequest updateRequest, User user, Gathering gathering) {
+
+        this.score = updateRequest.getScore();
+        this.comment = updateRequest.getComment();
+        this.gathering = gathering;
+        this.user = user;
     }
 
 }

--- a/src/main/java/com/manchui/domain/repository/ReviewRepository.java
+++ b/src/main/java/com/manchui/domain/repository/ReviewRepository.java
@@ -15,4 +15,6 @@ public interface ReviewRepository extends JpaRepository<Review, Long>, ReviewQue
 
     List<Review> findByGathering(Gathering gathering);
 
+    Optional<Review> findByIdAndDeletedAtIsNull(Long reviewId);
+
 }

--- a/src/main/java/com/manchui/domain/repository/querydsl/GatheringQueryDsl.java
+++ b/src/main/java/com/manchui/domain/repository/querydsl/GatheringQueryDsl.java
@@ -1,6 +1,6 @@
 package com.manchui.domain.repository.querydsl;
 
-import com.manchui.domain.dto.GatheringListResponse;
+import com.manchui.domain.dto.gathering.GatheringListResponse;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 

--- a/src/main/java/com/manchui/domain/repository/querydsl/GatheringQueryDslImpl.java
+++ b/src/main/java/com/manchui/domain/repository/querydsl/GatheringQueryDslImpl.java
@@ -1,6 +1,6 @@
 package com.manchui.domain.repository.querydsl;
 
-import com.manchui.domain.dto.GatheringListResponse;
+import com.manchui.domain.dto.gathering.GatheringListResponse;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.impl.JPAQuery;

--- a/src/main/java/com/manchui/domain/repository/querydsl/ReviewQueryDsl.java
+++ b/src/main/java/com/manchui/domain/repository/querydsl/ReviewQueryDsl.java
@@ -1,6 +1,6 @@
 package com.manchui.domain.repository.querydsl;
 
-import com.manchui.domain.dto.ReviewInfo;
+import com.manchui.domain.dto.review.ReviewInfo;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 

--- a/src/main/java/com/manchui/domain/repository/querydsl/ReviewQueryDslImpl.java
+++ b/src/main/java/com/manchui/domain/repository/querydsl/ReviewQueryDslImpl.java
@@ -1,6 +1,6 @@
 package com.manchui.domain.repository.querydsl;
 
-import com.manchui.domain.dto.ReviewInfo;
+import com.manchui.domain.dto.review.ReviewInfo;
 import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import jakarta.persistence.EntityManager;

--- a/src/main/java/com/manchui/domain/service/GatheringReader.java
+++ b/src/main/java/com/manchui/domain/service/GatheringReader.java
@@ -1,6 +1,6 @@
 package com.manchui.domain.service;
 
-import com.manchui.domain.dto.ReviewInfo;
+import com.manchui.domain.dto.review.ReviewInfo;
 import com.manchui.domain.dto.UserInfo;
 import com.manchui.domain.entity.Gathering;
 

--- a/src/main/java/com/manchui/domain/service/GatheringReader.java
+++ b/src/main/java/com/manchui/domain/service/GatheringReader.java
@@ -1,7 +1,7 @@
 package com.manchui.domain.service;
 
-import com.manchui.domain.dto.review.ReviewInfo;
 import com.manchui.domain.dto.UserInfo;
+import com.manchui.domain.dto.review.ReviewInfo;
 import com.manchui.domain.entity.Gathering;
 
 import java.util.List;
@@ -12,10 +12,12 @@ public interface GatheringReader {
 
     Gathering checkGatheringStatus(Long gatheringId);
 
-    Gathering checkGatheringStatusClosed(Long gatheringId);
+    Gathering checkGatheringStatusIsClosed(Long gatheringId);
 
     List<UserInfo> getUserInfoList(Gathering gathering);
 
     List<ReviewInfo> getReviewInfoList(Gathering gathering);
+
+    Gathering checkGatheringStatusIsCanceled(Long gatheringId);
 
 }

--- a/src/main/java/com/manchui/domain/service/GatheringReaderImpl.java
+++ b/src/main/java/com/manchui/domain/service/GatheringReaderImpl.java
@@ -1,7 +1,7 @@
 package com.manchui.domain.service;
 
-import com.manchui.domain.dto.review.ReviewInfo;
 import com.manchui.domain.dto.UserInfo;
+import com.manchui.domain.dto.review.ReviewInfo;
 import com.manchui.domain.entity.Attendance;
 import com.manchui.domain.entity.Gathering;
 import com.manchui.domain.entity.Review;
@@ -50,7 +50,7 @@ public class GatheringReaderImpl implements GatheringReader {
     }
 
     @Override
-    public Gathering checkGatheringStatusClosed(Long gatheringId) {
+    public Gathering checkGatheringStatusIsClosed(Long gatheringId) {
 
         Gathering gathering = checkGathering(gatheringId);
 
@@ -81,5 +81,19 @@ public class GatheringReaderImpl implements GatheringReader {
 
         return reviewInfoList;
     }
+
+    @Override
+    public Gathering checkGatheringStatusIsCanceled(Long gatheringId) {
+
+        Gathering gathering = checkGathering(gatheringId);
+
+        // 모임이 취소된 경우 예외 발생
+        if (gathering.isCanceled()) {
+            throw new CustomException(GATHERING_CANCELED);
+        }
+
+        return gathering;
+    }
+
 
 }

--- a/src/main/java/com/manchui/domain/service/GatheringReaderImpl.java
+++ b/src/main/java/com/manchui/domain/service/GatheringReaderImpl.java
@@ -1,6 +1,6 @@
 package com.manchui.domain.service;
 
-import com.manchui.domain.dto.ReviewInfo;
+import com.manchui.domain.dto.review.ReviewInfo;
 import com.manchui.domain.dto.UserInfo;
 import com.manchui.domain.entity.Attendance;
 import com.manchui.domain.entity.Gathering;

--- a/src/main/java/com/manchui/domain/service/GatheringService.java
+++ b/src/main/java/com/manchui/domain/service/GatheringService.java
@@ -1,9 +1,9 @@
 package com.manchui.domain.service;
 
-import com.manchui.domain.dto.GatheringCreateRequest;
-import com.manchui.domain.dto.GatheringCreateResponse;
-import com.manchui.domain.dto.GatheringInfoResponse;
-import com.manchui.domain.dto.GatheringPagingResponse;
+import com.manchui.domain.dto.gathering.GatheringCreateRequest;
+import com.manchui.domain.dto.gathering.GatheringCreateResponse;
+import com.manchui.domain.dto.gathering.GatheringInfoResponse;
+import com.manchui.domain.dto.gathering.GatheringPagingResponse;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 

--- a/src/main/java/com/manchui/domain/service/GatheringServiceImpl.java
+++ b/src/main/java/com/manchui/domain/service/GatheringServiceImpl.java
@@ -1,6 +1,11 @@
 package com.manchui.domain.service;
 
 import com.manchui.domain.dto.*;
+import com.manchui.domain.dto.gathering.GatheringCreateRequest;
+import com.manchui.domain.dto.gathering.GatheringCreateResponse;
+import com.manchui.domain.dto.gathering.GatheringInfoResponse;
+import com.manchui.domain.dto.gathering.GatheringPagingResponse;
+import com.manchui.domain.dto.review.ReviewInfo;
 import com.manchui.domain.entity.*;
 import com.manchui.domain.repository.*;
 import com.manchui.global.exception.CustomException;

--- a/src/main/java/com/manchui/domain/service/GatheringStore.java
+++ b/src/main/java/com/manchui/domain/service/GatheringStore.java
@@ -1,6 +1,6 @@
 package com.manchui.domain.service;
 
-import com.manchui.domain.dto.GatheringCreateRequest;
+import com.manchui.domain.dto.gathering.GatheringCreateRequest;
 import com.manchui.domain.entity.Gathering;
 import com.manchui.domain.entity.User;
 

--- a/src/main/java/com/manchui/domain/service/GatheringStoreImpl.java
+++ b/src/main/java/com/manchui/domain/service/GatheringStoreImpl.java
@@ -1,6 +1,6 @@
 package com.manchui.domain.service;
 
-import com.manchui.domain.dto.GatheringCreateRequest;
+import com.manchui.domain.dto.gathering.GatheringCreateRequest;
 import com.manchui.domain.entity.Attendance;
 import com.manchui.domain.entity.Gathering;
 import com.manchui.domain.entity.User;

--- a/src/main/java/com/manchui/domain/service/ReviewService.java
+++ b/src/main/java/com/manchui/domain/service/ReviewService.java
@@ -1,11 +1,14 @@
 package com.manchui.domain.service;
 
-import com.manchui.domain.dto.ReviewCreateResponse;
+import com.manchui.domain.dto.review.ReviewCreateRequest;
+import com.manchui.domain.dto.review.ReviewCreateResponse;
 import org.springframework.stereotype.Service;
 
 @Service
 public interface ReviewService {
 
-    ReviewCreateResponse createReview(String email, Long gatheringId, ReviewCreateResponse createResponse);
+    ReviewCreateResponse createReview(String email, Long gatheringId, ReviewCreateRequest createResponse);
+
+    ReviewCreateResponse updateReview(String email, Long reviewId, ReviewCreateRequest updateRequest);
 
 }

--- a/src/main/java/com/manchui/domain/service/ReviewService.java
+++ b/src/main/java/com/manchui/domain/service/ReviewService.java
@@ -11,4 +11,6 @@ public interface ReviewService {
 
     ReviewCreateResponse updateReview(String email, Long reviewId, ReviewCreateRequest updateRequest);
 
+    void deleteReview(String email, Long reviewId);
+
 }

--- a/src/main/java/com/manchui/domain/service/ReviewServiceImpl.java
+++ b/src/main/java/com/manchui/domain/service/ReviewServiceImpl.java
@@ -11,12 +11,14 @@ import com.manchui.domain.repository.ReviewRepository;
 import com.manchui.global.exception.CustomException;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 import java.util.Optional;
 
 import static com.manchui.global.exception.ErrorCode.*;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class ReviewServiceImpl implements ReviewService {
@@ -43,7 +45,7 @@ public class ReviewServiceImpl implements ReviewService {
         User user = userService.checkUser(email);
 
         // 마감된 모임만 후기 등록이 가능, 후기 유효성 검증 및 마감된 상태 체크
-        Gathering gathering = gatheringReader.checkGatheringStatusClosed(gatheringId);
+        Gathering gathering = gatheringReader.checkGatheringStatusIsClosed(gatheringId);
 
         // 유저가 해당 모임에 참석했는지 확인
         Optional<Attendance> existingAttendance = attendanceRepository.findByUserAndGathering(user, gathering);
@@ -61,6 +63,7 @@ public class ReviewServiceImpl implements ReviewService {
                 .build();
 
         reviewRepository.save(review);
+        log.info("{} 유저가 모임 id {}에 후기를 등록하였습니다.", user.getName(), gatheringId);
 
         return review.toResponseDto();
     }
@@ -78,23 +81,56 @@ public class ReviewServiceImpl implements ReviewService {
     @Transactional
     public ReviewCreateResponse updateReview(String email, Long reviewId, ReviewCreateRequest updateRequest) {
 
+        Review review = validateUserAndReview(email, reviewId);
+
+        // 모임 검증 (취소된 모임일 경우 예외 반환)
+        gatheringReader.checkGatheringStatusIsCanceled(review.getGathering().getId());
+
+        // 후기 수정
+        review.update(updateRequest, review.getUser(), review.getGathering());
+        log.info("모임 id {}의 후기 id {}이 수정되었습니다.", review.getGathering().getId(), reviewId);
+
+        return review.toResponseDto();
+    }
+
+    /**
+     * 2. 후기 삭제
+     * 작성자: 오예령
+     *
+     * @param email    유저 email
+     * @param reviewId 후기 id
+     */
+    @Override
+    @Transactional
+    public void deleteReview(String email, Long reviewId) {
+
+        Review review = validateUserAndReview(email, reviewId);
+
+        // 모임 검증 (취소된 모임일 경우 예외 반환)
+        gatheringReader.checkGatheringStatusIsCanceled(review.getGathering().getId());
+
+        // 후기 소프트 삭제
+        review.softDelete();
+        log.info("모임 id {}의 후기 id {}이 삭제되었습니다.", review.getGathering().getId(), reviewId);
+    }
+
+
+    private Review validateUserAndReview(String email, Long reviewId) {
+
         // 유저 검증
         User user = userService.checkUser(email);
 
-        // 후기 검증
-        Review review = reviewRepository.findById(reviewId).orElseThrow(
+        // 후기 검증 (이미 삭제 처리된 후기는 수정/삭제 불가능)
+        Review review = reviewRepository.findByIdAndDeletedAtIsNull(reviewId).orElseThrow(
                 () -> new CustomException(REVIEW_NOT_FOUND)
         );
 
-        // 모임 검증
-        Long gatheringId = review.getGathering().getId();
+        // 본인 후기인지 확인
+        if (!review.getUser().equals(user)) {
+            throw new CustomException(PERMISSION_DENIED);
+        }
 
-        Gathering gathering = gatheringReader.checkGatheringStatusClosed(gatheringId);
-
-        // 후기 수정
-        review.update(updateRequest, user, gathering);
-
-        return review.toResponseDto();
+        return review;
     }
 
 }

--- a/src/main/java/com/manchui/global/exception/ErrorCode.java
+++ b/src/main/java/com/manchui/global/exception/ErrorCode.java
@@ -38,6 +38,7 @@ public enum ErrorCode {
     // review
     ILLEGAL_GATHERING_STATUS(HttpStatus.BAD_REQUEST, "마감된 모임만 후기 등록이 가능합니다."),
     ALREADY_REVIEW_EXIST(HttpStatus.BAD_REQUEST, "참여한 모임에 대한 후기는 1회만 등록 가능합니다."),
+    REVIEW_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 후기입니다."),
 
     // image
     ILLEGAL_EMPTY_FILE(HttpStatus.BAD_REQUEST, "이미지 파일은 필수 입력 값입니다."),

--- a/src/main/java/com/manchui/global/exception/ErrorCode.java
+++ b/src/main/java/com/manchui/global/exception/ErrorCode.java
@@ -39,6 +39,7 @@ public enum ErrorCode {
     ILLEGAL_GATHERING_STATUS(HttpStatus.BAD_REQUEST, "마감된 모임만 후기 등록이 가능합니다."),
     ALREADY_REVIEW_EXIST(HttpStatus.BAD_REQUEST, "참여한 모임에 대한 후기는 1회만 등록 가능합니다."),
     REVIEW_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 후기입니다."),
+    PERMISSION_DENIED(HttpStatus.BAD_REQUEST, "본인이 작성한 후기만 수정/삭제가 가능합니다."),
 
     // image
     ILLEGAL_EMPTY_FILE(HttpStatus.BAD_REQUEST, "이미지 파일은 필수 입력 값입니다."),

--- a/src/main/java/com/manchui/global/jwt/JWTFilter.java
+++ b/src/main/java/com/manchui/global/jwt/JWTFilter.java
@@ -39,8 +39,8 @@ public class JWTFilter extends OncePerRequestFilter {
         if ((requestUri.matches("^\\/api\\/auths\\/signup$") && requestMethod.equals("POST")) ||
                 (requestUri.matches("^\\/api\\/auths\\/check-name$") && requestMethod.equals("POST")) ||
                 (requestUri.matches("^\\/api\\/auths\\/signin$") && requestMethod.equals("POST")) ||
-                (requestUri.matches("^\\/api\\/gatherings\\/public$") && requestMethod.equals("GET"))
-            ){
+                (requestUri.matches("^\\/api\\/gatherings\\/public.*$") && requestMethod.equals("GET"))
+        ) {
             filterChain.doFilter(request, response);
             return;
         }
@@ -64,6 +64,7 @@ public class JWTFilter extends OncePerRequestFilter {
     }
 
     private String validateAccessToken(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+
         String authorization = request.getHeader("Authorization");
 
         if (authorization == null || !authorization.startsWith("Bearer ")) {
@@ -73,7 +74,7 @@ public class JWTFilter extends OncePerRequestFilter {
         }
 
         //Bearer 부분 제거 후 순수 토큰만 획득
-        String accessToken= authorization.split(" ")[1];
+        String accessToken = authorization.split(" ")[1];
 
         //응답 header에 accessToken이 없는 경우
         if (accessToken == null) {
@@ -112,6 +113,7 @@ public class JWTFilter extends OncePerRequestFilter {
 
     // 예외 처리 응답을 직접 설정하는 메서드
     private void handleException(HttpServletResponse response, ErrorCode errorCode) {
+
         response.setStatus(errorCode.getHttpStatus().value());
         response.setContentType("application/json");
         response.setCharacterEncoding("UTF-8");
@@ -129,4 +131,5 @@ public class JWTFilter extends OncePerRequestFilter {
             log.error("Failed to write error response", e);
         }
     }
+
 }


### PR DESCRIPTION
## #️⃣ Issue Number

<!--- ex) #이슈번호, #이슈번호 -->
#55 

## 📝 요약(Summary)

<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

- 후기 삭제 기능을 구현했습니다.
- 후기 수정 및 삭제 기능에 대해 해당 유저의 후기인지 검증하는 로직을 추가했습니다.
- 발생하는 예외를 세분화하여 관리하기 쉽게 분리했습니다.
- 비회원의 모임 상세 조회 시의 URI를 JWTFilter 클래스의 허용 경로에 포함하도록 수정했습니다.

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [X] 새로운 기능 추가
- [X] 버그 수정
- [X] 코드 리팩토링
