### PR TITLE
[Fix] 프론트서버와 백엔드 서버 연결 문제 및 쿠키 교환 문제 해결

### DIFF
--- a/src/main/java/com/manchui/global/config/CorsMvcConfig.java
+++ b/src/main/java/com/manchui/global/config/CorsMvcConfig.java
@@ -11,10 +11,10 @@ public class CorsMvcConfig implements WebMvcConfigurer {
     public void addCorsMappings(CorsRegistry corsRegistry) {
 
         corsRegistry.addMapping("/**")
-                .allowedOrigins("http://localhost:3000", "http://13.125.37.151:8080") // 여러 원본을 하나의 호출로
+                .allowedOrigins("http://localhost:3000", "http://13.125.37.151:8080", "https://manchui.vercel.app") // 여러 원본을 하나의 호출로
                 .allowedMethods("*")
                 .allowedHeaders("*")
-                .exposedHeaders("Authorization")
+                .exposedHeaders("Authorization", "Set-Cookie")
                 .allowCredentials(true);
     }
 

--- a/src/main/java/com/manchui/global/config/SecurityConfig.java
+++ b/src/main/java/com/manchui/global/config/SecurityConfig.java
@@ -63,13 +63,13 @@ public class SecurityConfig {
                     public CorsConfiguration getCorsConfiguration(HttpServletRequest request) {
                         CorsConfiguration configuration = new CorsConfiguration();
 
-                        configuration.setAllowedOrigins(Collections.singletonList("http://localhost:3000"));
+                        configuration.setAllowedOrigins(Arrays.asList("http://localhost:3000", "https://manchui.vercel.app"));
                         configuration.setAllowedMethods(Collections.singletonList("*"));
                         configuration.setAllowCredentials(true);
                         configuration.setAllowedHeaders(Collections.singletonList("*"));
                         configuration.setMaxAge(3600L);
 
-                        configuration.setExposedHeaders(Collections.singletonList("Authorization"));
+                        configuration.setExposedHeaders(Arrays.asList("Authorization", "Set-Cookie"));
 
                         return configuration;
                     }

--- a/src/main/java/com/manchui/global/jwt/LoginFilter.java
+++ b/src/main/java/com/manchui/global/jwt/LoginFilter.java
@@ -14,6 +14,8 @@ import jakarta.validation.ConstraintViolation;
 import jakarta.validation.Validator;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
@@ -102,7 +104,7 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
         redisRefreshTokenService.saveAccessToken(userEmail, access, accessTokenExpiration);
 
         response.setHeader("Authorization", "Bearer " + access);
-        response.addCookie(createCookie("refresh", refresh));
+        setResponseCookie(response, "refresh", refresh);
 
         response.setStatus(HttpServletResponse.SC_OK);
         response.setContentType("application/json");
@@ -116,6 +118,17 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
                 "}";
 
         response.getWriter().write(jsonResponse);
+    }
+
+    private void setResponseCookie(HttpServletResponse response, String key, String value) {
+        ResponseCookie cookie = ResponseCookie.from(key, value)
+                .maxAge(24 * 60 * 60)
+                .sameSite("None")
+                .secure(true)
+                .httpOnly(true)
+                .path("/")
+                .build();
+        response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
     }
 
     //로그인 실패시 실행


### PR DESCRIPTION
## #️⃣ Issue Number

<!--- ex) #이슈번호, #이슈번호 -->
#64 

## 📝 요약(Summary)

<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
 - Mixed Content 문제
 - Mixed Content 경고는 HTTPS로 로드된 페이지에서 HTTP로 리소스를 요청했기 때문에 발생
   - 도메인을 구매하여 certbot을 사용하여 SSL 인증서를 발급받고, Nginx에 적용하여 백엔드 서버가 HTTPS를 통해 요청을 처리하도록 설정하여 해결
 - 로그인시 받은 쿠키가 백엔드 서버에 전달이 되지 않는 문제
   - 로그인시 백엔드에서 반환하는 refresh 토큰의 쿠키 속성을 sameSite을 None으로 설정하고 secure을 활성화 해서 전달하여 해결

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [X] 버그 수정
