### PR TITLE
[Refactor] 모임 목록 조회 시 회원/비회원 API 통합

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -54,12 +54,12 @@ dependencies {
     implementation 'io.jsonwebtoken:jjwt-impl:0.12.3'
     implementation 'io.jsonwebtoken:jjwt-jackson:0.12.3'
 
-	  //Redis 의존성
-  	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    //Redis 의존성
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
-  	// aws
-	  implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
-  	implementation 'com.amazonaws:aws-java-sdk-s3'
+    // aws
+    implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
+    implementation 'com.amazonaws:aws-java-sdk-s3'
 
     // querydsl
     implementation "com.querydsl:querydsl-jpa:5.0.0:jakarta"

--- a/src/main/java/com/manchui/domain/controller/GatheringController.java
+++ b/src/main/java/com/manchui/domain/controller/GatheringController.java
@@ -46,49 +46,28 @@ public class GatheringController {
 
     }
 
-    @Operation(summary = "모임 목록 조회 (비회원)", description = "비회원이 요청하는 모임의 목록을 반환합니다.")
+    @Operation(summary = "모임 목록 조회", description = "회원 또는 비회원이 요청하는 모임의 목록을 반환합니다.")
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "비회원이 요청한 목록이 반환되었습니다.",
+            @ApiResponse(responseCode = "200", description = "요청한 목록이 반환되었습니다.",
                     content = @Content(mediaType = "application/json")),
             @ApiResponse(responseCode = "400", description = "요청 값을 확인해주세요."),
             @ApiResponse(responseCode = "404", description = "해당하는 모임이 없습니다.")
     })
     @GetMapping("/public")
-    public ResponseEntity<SuccessResponse<GatheringPagingResponse>> getGatheringByGuest(@RequestParam(defaultValue = "1") int page,
-                                                                                        @RequestParam int size,
-                                                                                        @RequestParam(required = false) String query,
-                                                                                        @RequestParam(required = false) String location,
-                                                                                        @RequestParam(required = false) String startDate,
-                                                                                        @RequestParam(required = false) String endDate,
-                                                                                        @RequestParam(required = false) String category,
-                                                                                        @RequestParam(required = false) String sort) {
+    public ResponseEntity<SuccessResponse<GatheringPagingResponse>> getGatherings(@AuthenticationPrincipal CustomUserDetails userDetails,
+                                                                                  @RequestParam(defaultValue = "1") int page,
+                                                                                  @RequestParam int size,
+                                                                                  @RequestParam(required = false) String query,
+                                                                                  @RequestParam(required = false) String location,
+                                                                                  @RequestParam(required = false) String startDate,
+                                                                                  @RequestParam(required = false) String endDate,
+                                                                                  @RequestParam(required = false) String category,
+                                                                                  @RequestParam(required = false) String sort) {
 
         Pageable pageable = PageRequest.of(page - 1, size, Sort.by("createdAt").descending());
-        return ResponseEntity.ok(SuccessResponse.successWithData(gatheringService.getGatheringByGuest(pageable, query, location, startDate, endDate, category, sort)));
+        GatheringPagingResponse response = gatheringService.getGatherings(userDetails, pageable, query, location, startDate, endDate, category, sort);
 
-    }
-
-    @Operation(summary = "모임 목록 조회 (회원)", description = "회원이 요청하는 모임의 목록을 반환합니다.")
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "회원이 요청한 목록이 반환되었습니다.",
-                    content = @Content(mediaType = "application/json")),
-            @ApiResponse(responseCode = "400", description = "요청 값을 확인해주세요."),
-            @ApiResponse(responseCode = "404", description = "해당하는 모임이 없습니다.")
-    })
-    @GetMapping("")
-    public ResponseEntity<SuccessResponse<GatheringPagingResponse>> getGatheringByUser(@AuthenticationPrincipal CustomUserDetails userDetails,
-                                                                                       @RequestParam(defaultValue = "1") int page,
-                                                                                       @RequestParam int size,
-                                                                                       @RequestParam(required = false) String query,
-                                                                                       @RequestParam(required = false) String location,
-                                                                                       @RequestParam(required = false) String startDate,
-                                                                                       @RequestParam(required = false) String endDate,
-                                                                                       @RequestParam(required = false) String category,
-                                                                                       @RequestParam(required = false) String sort) {
-
-        Pageable pageable = PageRequest.of(page - 1, size, Sort.by("createdAt").descending());
-        return ResponseEntity.ok(SuccessResponse.successWithData(gatheringService.getGatheringByUser(userDetails.getUsername(), pageable, query, location, startDate, endDate, category, sort)));
-
+        return ResponseEntity.ok(SuccessResponse.successWithData(response));
     }
 
     @Operation(summary = "모임 참여", description = "모임에 참여합니다.")

--- a/src/main/java/com/manchui/domain/dto/CustomUserDetails.java
+++ b/src/main/java/com/manchui/domain/dto/CustomUserDetails.java
@@ -14,38 +14,51 @@ public class CustomUserDetails implements UserDetails {
 
     private final User user;
 
+    public boolean isGuest() {
+
+        return this.getUsername() == null || this.getUsername().isEmpty();
+    }
+
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
+
         return null;
     }
 
     @Override
     public String getPassword() {
+
         return user.getPassword();
     }
 
     @Override
     public String getUsername() {
+
         return user.getEmail();
     }
 
     @Override
     public boolean isAccountNonExpired() {
+
         return UserDetails.super.isAccountNonExpired();
     }
 
     @Override
     public boolean isAccountNonLocked() {
+
         return UserDetails.super.isAccountNonLocked();
     }
 
     @Override
     public boolean isCredentialsNonExpired() {
+
         return UserDetails.super.isCredentialsNonExpired();
     }
 
     @Override
     public boolean isEnabled() {
+
         return UserDetails.super.isEnabled();
     }
+
 }

--- a/src/main/java/com/manchui/domain/dto/gathering/GatheringCreateRequest.java
+++ b/src/main/java/com/manchui/domain/dto/gathering/GatheringCreateRequest.java
@@ -54,7 +54,6 @@ public class GatheringCreateRequest {
                 .maxUsers(maxUsers)
                 .minUsers(minUsers)
                 .gatheringContent(gatheringContent)
-                .isHearted(false)
                 .isOpened(false)
                 .isCanceled(false)
                 .isClosed(false)

--- a/src/main/java/com/manchui/domain/dto/gathering/GatheringPagingResponse.java
+++ b/src/main/java/com/manchui/domain/dto/gathering/GatheringPagingResponse.java
@@ -22,7 +22,7 @@ public class GatheringPagingResponse {
         this.gatheringCount = (int) pageList.getTotalElements();
         this.gatheringList = pageList.getContent();
         this.pageSize = pageList.getSize();
-        this.page = pageList.getPageable().getPageNumber();
+        this.page = pageList.getPageable().getPageNumber() + 1;
         this.totalPage = pageList.getTotalPages();
 
     }

--- a/src/main/java/com/manchui/domain/dto/review/ReviewDetailPagingResponse.java
+++ b/src/main/java/com/manchui/domain/dto/review/ReviewDetailPagingResponse.java
@@ -28,7 +28,7 @@ public class ReviewDetailPagingResponse {
         this.scoreList = scoreInfo;
         this.reviewContentList = pageList.getContent();
         this.pageSize = pageList.getSize();
-        this.page = pageList.getPageable().getPageNumber();
+        this.page = pageList.getPageable().getPageNumber() + 1;
         this.totalPage = pageList.getTotalPages();
     }
 

--- a/src/main/java/com/manchui/domain/entity/Gathering.java
+++ b/src/main/java/com/manchui/domain/entity/Gathering.java
@@ -65,11 +65,6 @@ public class Gathering extends Timestamped {
     @Comment("모집 최소 인원")
     private int minUsers = 2;
 
-    @Column(name = "is_hearted")
-    @Comment("좋아요 여부")
-    @Builder.Default
-    private boolean isHearted = false;
-
     @Column(name = "is_opened")
     @Comment("개설여부")
     @Builder.Default

--- a/src/main/java/com/manchui/domain/repository/GatheringRepository.java
+++ b/src/main/java/com/manchui/domain/repository/GatheringRepository.java
@@ -14,4 +14,5 @@ public interface GatheringRepository extends JpaRepository<Gathering, Long>, Gat
     Page<Gathering> findByUserEquals(User user, Pageable pageable);
 
     Page<Gathering> findByIdIn(List<Long> gatheringIdList, Pageable pageable);
+
 }

--- a/src/main/java/com/manchui/domain/repository/ReviewRepository.java
+++ b/src/main/java/com/manchui/domain/repository/ReviewRepository.java
@@ -15,10 +15,10 @@ public interface ReviewRepository extends JpaRepository<Review, Long>, ReviewQue
 
     Optional<Review> findByGatheringAndUser(Gathering gathering, User user);
 
-    List<Review> findByGathering(Gathering gathering);
-
     Page<Review> findByUser(User user, Pageable pageable);
+
     Optional<Review> findByIdAndDeletedAtIsNull(Long reviewId);
 
     List<Review> findByUserAndDeletedAtIsNull(User user);
+
 }

--- a/src/main/java/com/manchui/domain/service/GatheringService.java
+++ b/src/main/java/com/manchui/domain/service/GatheringService.java
@@ -1,5 +1,6 @@
 package com.manchui.domain.service;
 
+import com.manchui.domain.dto.CustomUserDetails;
 import com.manchui.domain.dto.gathering.GatheringCreateRequest;
 import com.manchui.domain.dto.gathering.GatheringCreateResponse;
 import com.manchui.domain.dto.gathering.GatheringInfoResponse;
@@ -12,9 +13,7 @@ public interface GatheringService {
 
     GatheringCreateResponse createGathering(String email, GatheringCreateRequest createRequest);
 
-    GatheringPagingResponse getGatheringByGuest(Pageable pageable, String query, String location, String startDate, String endDate, String category, String sort);
-
-    GatheringPagingResponse getGatheringByUser(String email, Pageable pageable, String query, String location, String startDate, String endDate, String category, String sort);
+    GatheringPagingResponse getGatherings(CustomUserDetails userDetails, Pageable pageable, String query, String location, String startDate, String endDate, String category, String sort);
 
     void joinGathering(String email, Long gatheringId);
 

--- a/src/main/java/com/manchui/domain/service/ImageServiceImpl.java
+++ b/src/main/java/com/manchui/domain/service/ImageServiceImpl.java
@@ -18,20 +18,21 @@ import java.util.UUID;
 @RequiredArgsConstructor
 public class ImageServiceImpl {
 
-    private final ImageRepository imageRepository;
-    private final S3Uploader s3Uploader;
-
     private static final Set<String> VALID_EXTENSIONS = new HashSet<>(Arrays.asList("gif", "png", "jpg", "jpeg",
             "GIF", "PNG", "JPG", "JPEG"));
+    private final ImageRepository imageRepository;
+    private final S3Uploader s3Uploader;
 
     // 모임의 Image 등록
     @Transactional
     public void uploadGatheringImage(MultipartFile multipartFile, Long gatheringId) {
+
         imageRepository.save(toImageEntity(multipartFile, gatheringId));
 
     }
 
     public Long uploadUserProfileImage(MultipartFile multipartFile) {
+
         return imageRepository.save(toImageEntity(multipartFile, null)).getImageId();
     }
 
@@ -39,17 +40,17 @@ public class ImageServiceImpl {
     // MultipartFile 을 Image Entity 형태로 변경
     public Image toImageEntity(MultipartFile multipartFile, Long gatheringId) {
 
-        if(multipartFile.isEmpty()) throw new CustomException(ErrorCode.ILLEGAL_EMPTY_FILE);
+        if (multipartFile.isEmpty()) throw new CustomException(ErrorCode.ILLEGAL_EMPTY_FILE);
 
         String fakeFileName = createRandomFileName(multipartFile.getOriginalFilename());
         String originalFileName = multipartFile.getOriginalFilename();
         String filePath = s3Uploader.uploadImage(multipartFile, fakeFileName);
 
-        if(gatheringId == null){
+        if (gatheringId == null) {
             return new Image(originalFileName, fakeFileName, filePath);
         }
 
-        return new Image(originalFileName, fakeFileName,  filePath, gatheringId);
+        return new Image(originalFileName, fakeFileName, filePath, gatheringId);
 
     }
 
@@ -75,9 +76,9 @@ public class ImageServiceImpl {
                 throw new CustomException(ErrorCode.WRONG_TYPE_IMAGE);
             }
             return "." + extension;
-        }
-        catch (IndexOutOfBoundsException e) {
+        } catch (IndexOutOfBoundsException e) {
             throw new CustomException(ErrorCode.WRONG_TYPE_IMAGE);
         }
     }
+
 }

--- a/src/main/java/com/manchui/global/config/CorsMvcConfig.java
+++ b/src/main/java/com/manchui/global/config/CorsMvcConfig.java
@@ -11,7 +11,7 @@ public class CorsMvcConfig implements WebMvcConfigurer {
     public void addCorsMappings(CorsRegistry corsRegistry) {
 
         corsRegistry.addMapping("/**")
-                .allowedOrigins("http://localhost:3000", "http://13.125.37.151:8080", "https://manchui.vercel.app") // 여러 원본을 하나의 호출로
+                .allowedOrigins("http://localhost:3000", "https://manchui.vercel.app/") // 여러 원본을 하나의 호출로
                 .allowedMethods("*")
                 .allowedHeaders("*")
                 .exposedHeaders("Authorization", "Set-Cookie")

--- a/src/main/java/com/manchui/global/config/SecurityConfig.java
+++ b/src/main/java/com/manchui/global/config/SecurityConfig.java
@@ -23,6 +23,7 @@ import org.springframework.security.web.authentication.logout.LogoutFilter;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 
+import java.util.Arrays;
 import java.util.Collections;
 
 @Configuration

--- a/src/main/java/com/manchui/global/jwt/JWTFilter.java
+++ b/src/main/java/com/manchui/global/jwt/JWTFilter.java
@@ -49,13 +49,18 @@ public class JWTFilter extends OncePerRequestFilter {
         String authorization = request.getHeader("Authorization");
 
         // /api/gatherings/public/** 요청에 대한 처리
-        if (requestUri.matches("^/api/gatherings/public.*$") && requestMethod.equals("GET"))
-
+        if (requestUri.matches("^/api/gatherings/public.*$") && requestMethod.equals("GET")) {
             log.info("모임 전체 목록 조회 요청");
-        // 토큰이 없는 경우 비회원으로 처리
-        if (authorization == null || !authorization.startsWith("Bearer ")) {
-            filterChain.doFilter(request, response);
-            return;
+            // 토큰이 없는 경우 비회원으로 처리
+            if (authorization == null || !authorization.startsWith("Bearer ")) {
+                filterChain.doFilter(request, response);
+                return;
+            }
+        } else {
+            if (authorization == null || !authorization.startsWith("Bearer ")) {
+                handleException(response, ErrorCode.MISSING_AUTHORIZATION_ACCESS_TOKEN);
+                return;
+            }
         }
 
         try {

--- a/src/main/java/com/manchui/global/jwt/JWTFilter.java
+++ b/src/main/java/com/manchui/global/jwt/JWTFilter.java
@@ -56,11 +56,6 @@ public class JWTFilter extends OncePerRequestFilter {
                 filterChain.doFilter(request, response);
                 return;
             }
-        } else {
-            if (authorization == null || !authorization.startsWith("Bearer ")) {
-                handleException(response, ErrorCode.MISSING_AUTHORIZATION_ACCESS_TOKEN);
-                return;
-            }
         }
 
         try {


### PR DESCRIPTION
## #️⃣ Issue Number

<!--- ex) #이슈번호, #이슈번호 -->
#63 

## 📝 요약(Summary)

<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

- 프론트엔드 분의 요청으로 모임 목록 조회 시의 API를 통합하였습니다.
- 백엔드 차원에서도 추후 성능 최적화를 적용할 때 공통 데이터를 한 번에 처리할 수 있어 리소스 절감과 성능 측면에서 유리하다고 판단되어 통합하였습니다.
- 해당 API 요청이 들어오는 경우 토큰이 있는 경우에는 검증이 필요하기 때문에 JWTFilter에 해당 경로의 조건을 추가하였습니다.
- 찜한 목록 조회 시 필터링이 누락되어 있어 정상작동 되지 않던 부분을 수정하였습니다.
- 페이징 목록 반환 시 API 엔드포인트의 pageNumber와 반환되는 pageNumber의 숫자를 통일하기 위해 각 dto의 페이지 넘버에 +1을 추가하였습니다.

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [X] 버그 수정
- [X] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [X] 코드 리팩토링
- [X] 주석 추가 및 수정
- [X] 파일 혹은 폴더 삭제
