### PR TITLE
[Refactor] 토큰 재발급시 AccessToken을 redis에 저장 기능 추가 및 쿠키 옵션 수정

### DIFF
--- a/src/main/java/com/manchui/domain/controller/UserController.java
+++ b/src/main/java/com/manchui/domain/controller/UserController.java
@@ -36,7 +36,7 @@ public class UserController {
                                                           @ModelAttribute @Valid UserEditInfoRequest userEditInfoRequest) {
 
         String userEmail = userDetails.getUsername();
-        userService.checkName(userEditInfoRequest.getName());
+        userService.checkName(userEditInfoRequest.getName(), userEmail);
         UUID userId = userService.editUserInfo(userEmail, userEditInfoRequest);
         User user = userService.findByUserId(userId);
         UserEditInfoResponse response = UserEditInfoResponse.builder()

--- a/src/main/java/com/manchui/domain/dto/User/WrittenReviewInfo.java
+++ b/src/main/java/com/manchui/domain/dto/User/WrittenReviewInfo.java
@@ -16,6 +16,7 @@ public class WrittenReviewInfo {
     private String groupName;
     private String category;
     private String location;
+    private String comment;
     private String gatheringImage;
     private LocalDateTime gatheringDate;
     private LocalDateTime createdAt;

--- a/src/main/java/com/manchui/domain/service/UserService.java
+++ b/src/main/java/com/manchui/domain/service/UserService.java
@@ -78,7 +78,10 @@ public class UserService {
     }
 
     //유저 이름 중복 확인
-    public void checkName(String name) {
+    public void checkName(String name, String userEmail) {
+        if (userRepository.findByEmail(userEmail).getName().equals(name)) {
+            return;
+        }
         if (userRepository.existsByName(name)) {
             throw new CustomException(ILLEGAL_USERNAME_DUPLICATION);
         }

--- a/src/main/java/com/manchui/domain/service/UserService.java
+++ b/src/main/java/com/manchui/domain/service/UserService.java
@@ -157,7 +157,7 @@ public class UserService {
 
             return new WrittenReviewInfo(m.getGathering().getId(), m.getScore(),
                     m.getGathering().getGroupName(), m.getGathering().getCategory(),
-                    m.getGathering().getLocation(), filePath, m.getGathering().getGatheringDate(), m.getCreatedAt(), m.getUpdatedAt());
+                    m.getGathering().getLocation(), m.getComment(),filePath, m.getGathering().getGatheringDate(), m.getCreatedAt(), m.getUpdatedAt());
         });
         //응답 데이터 반환
         return new UserWrittenReviewsResponse(writtenReviewInfos.getNumberOfElements(), writtenReviewInfos,

--- a/src/main/java/com/manchui/global/jwt/JWTFilter.java
+++ b/src/main/java/com/manchui/global/jwt/JWTFilter.java
@@ -39,7 +39,8 @@ public class JWTFilter extends OncePerRequestFilter {
         if ((requestUri.matches("^\\/api\\/auths\\/signup$") && requestMethod.equals("POST")) ||
                 (requestUri.matches("^\\/api\\/auths\\/check-name$") && requestMethod.equals("POST")) ||
                 (requestUri.matches("^\\/api\\/auths\\/signin$") && requestMethod.equals("POST")) ||
-                (requestUri.matches("^\\/api\\/reviews$") && requestMethod.equals("GET"))) {
+                (requestUri.matches("^\\/api\\/reviews$") && requestMethod.equals("GET")) ||
+                (requestUri.matches("^\\/api\\/auths\\/reissue$") && requestMethod.equals("POST"))) {
             filterChain.doFilter(request, response);
             return;
         }


### PR DESCRIPTION
## #️⃣ Issue Number

<!--- ex) #이슈번호, #이슈번호 -->
#74 

## 📝 요약(Summary)

<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
- 사용자가 작성한 리뷰 조회 API 요청시 리뷰의 내용이 없는 문제가 생겨서 작성한 리뷰의 내용을 추가하였습니다.
-  유저 정보 수정시 현재 닉네임과 동일한 닉네임으로 변경시 닉네임 중복 예외가 발생하여 이와 같은 경우 중복 예외가 발생하지 않도록 변경하였습니다.
- 토큰 재발급 요청시 AccessToken을 검증하는 문제가 발생하여 AcessToken 검증 생략하도록 수정하였습니다.
- 토큰 재발급하여 받은 AccessToken이 유효하지 않은 토큰으로 나오는 문제가 발생하여 토큰 재발급시 AccessToken을 redis에 저장하고 쿠키가 프론트서버와 백엔드 서버에서 교환할수 있게 쿠키 옵션을 SameSite를 None으로 설정하고 secure을 활성화 시켜주었습니다.


## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [X] 새로운 기능 추가
- [X] 버그 수정
- [X] 코드 리팩토링
