### PR TITLE
[Refactor] 모임 목록 조회 시 페이지네이션 구현 방법 수정

### DIFF
--- a/src/main/java/com/manchui/domain/controller/GatheringController.java
+++ b/src/main/java/com/manchui/domain/controller/GatheringController.java
@@ -1,19 +1,16 @@
 package com.manchui.domain.controller;
 
 import com.manchui.domain.dto.CustomUserDetails;
-import com.manchui.domain.dto.gathering.GatheringCreateRequest;
-import com.manchui.domain.dto.gathering.GatheringCreateResponse;
-import com.manchui.domain.dto.gathering.GatheringInfoResponse;
-import com.manchui.domain.dto.gathering.GatheringPagingResponse;
+import com.manchui.domain.dto.gathering.*;
 import com.manchui.domain.service.GatheringService;
 import com.manchui.global.response.SuccessResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
@@ -21,10 +18,10 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
+@Tag(name = "Gatherings")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/gatherings")
-@Slf4j
 public class GatheringController {
 
     private final GatheringService gatheringService;
@@ -54,20 +51,18 @@ public class GatheringController {
             @ApiResponse(responseCode = "404", description = "해당하는 모임이 없습니다.")
     })
     @GetMapping("/public")
-    public ResponseEntity<SuccessResponse<GatheringPagingResponse>> getGatherings(@AuthenticationPrincipal CustomUserDetails userDetails,
-                                                                                  @RequestParam(defaultValue = "1") int page,
-                                                                                  @RequestParam int size,
-                                                                                  @RequestParam(required = false) String query,
-                                                                                  @RequestParam(required = false) String location,
-                                                                                  @RequestParam(required = false) String startDate,
-                                                                                  @RequestParam(required = false) String endDate,
-                                                                                  @RequestParam(required = false) String category,
-                                                                                  @RequestParam(required = false) String sort,
-                                                                                  @RequestParam(required = false) boolean available) {
+    public ResponseEntity<SuccessResponse<GatheringCursorPagingResponse>> getGatherings(@AuthenticationPrincipal CustomUserDetails userDetails,
+                                                                                        @RequestParam(required = false) Long cursor, // 커서 파라미터 추가
+                                                                                        @RequestParam int size,
+                                                                                        @RequestParam(required = false) String query,
+                                                                                        @RequestParam(required = false) String location,
+                                                                                        @RequestParam(required = false) String startDate,
+                                                                                        @RequestParam(required = false) String endDate,
+                                                                                        @RequestParam(required = false) String category,
+                                                                                        @RequestParam(required = false) String sort,
+                                                                                        @RequestParam(required = false, defaultValue = "false") boolean available) {
 
-        Pageable pageable = PageRequest.of(page - 1, size, Sort.by("createdAt").descending());
-        GatheringPagingResponse response = gatheringService.getGatherings(userDetails, pageable, query, location, startDate, endDate, category, sort, available);
-
+        GatheringCursorPagingResponse response = gatheringService.getGatherings(userDetails, cursor, size, query, location, startDate, endDate, category, sort, available);
         return ResponseEntity.ok(SuccessResponse.successWithData(response));
     }
 
@@ -154,11 +149,11 @@ public class GatheringController {
         return ResponseEntity.ok(SuccessResponse.successWithData(gatheringService.getGatheringInfoByUser(userDetails.getUsername(), gatheringId, pageable)));
     }
 
-    @Operation(summary = "찜한 모임 목록 조회", description = "회원이 찜한 모임 목록을 반환합니다.")
+    @Operation(summary = "모임 취소", description = "모임을 취소합니다.")
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "회원의 찜한 모임 목록입니다.",
+            @ApiResponse(responseCode = "200", description = "모임이 취소되었습니다.",
                     content = @Content(mediaType = "application/json")),
-            @ApiResponse(responseCode = "404", description = "찜한 모임이 없습니다.")
+            @ApiResponse(responseCode = "404", description = "해당하는 모임이 없습니다.")
     })
     @PatchMapping("/{gatheringId}/cancel")
     public ResponseEntity<SuccessResponse<String>> cancelGathering(@AuthenticationPrincipal CustomUserDetails userDetails,
@@ -184,11 +179,10 @@ public class GatheringController {
                                                                                  @RequestParam(required = false) String endDate,
                                                                                  @RequestParam(required = false) String category,
                                                                                  @RequestParam(required = false) String sort,
-                                                                                 @RequestParam(required = false) boolean available) {
+                                                                                 @RequestParam(required = false, defaultValue = "false") boolean available) {
 
         Pageable pageable = PageRequest.of(page - 1, size, Sort.by("createdAt").descending());
         return ResponseEntity.ok(SuccessResponse.successWithData(gatheringService.getHeartList(userDetails.getUsername(), pageable, query, location, startDate, endDate, category, sort, available)));
     }
 
 }
-

--- a/src/main/java/com/manchui/domain/controller/JoinController.java
+++ b/src/main/java/com/manchui/domain/controller/JoinController.java
@@ -4,6 +4,7 @@ import com.manchui.domain.dto.JoinDTO;
 import com.manchui.domain.dto.NameDTO;
 import com.manchui.domain.service.JoinService;
 import com.manchui.global.response.SuccessResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -13,6 +14,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "Join")
 @Slf4j
 @RestController
 @RequiredArgsConstructor
@@ -35,4 +37,5 @@ public class JoinController {
 
         return ResponseEntity.ok().body(SuccessResponse.successWithNoData("사용 가능한 이름 입니다."));
     }
+
 }

--- a/src/main/java/com/manchui/domain/controller/ReissueController.java
+++ b/src/main/java/com/manchui/domain/controller/ReissueController.java
@@ -1,9 +1,8 @@
 package com.manchui.domain.controller;
 
 import com.manchui.domain.service.ReissueService;
-import com.manchui.global.jwt.JWTFilter;
-import com.manchui.global.jwt.JWTUtil;
 import com.manchui.global.response.SuccessResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
@@ -11,6 +10,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "Token")
 @RestController
 @RequiredArgsConstructor
 public class ReissueController {
@@ -18,8 +18,9 @@ public class ReissueController {
     private final ReissueService reissueService;
 
     @PostMapping("/api/auths/reissue")
-    public ResponseEntity<SuccessResponse<Void>> reissue(HttpServletRequest request, HttpServletResponse response){
+    public ResponseEntity<SuccessResponse<Void>> reissue(HttpServletRequest request, HttpServletResponse response) {
 
         return reissueService.reissue(request, response);
     }
+
 }

--- a/src/main/java/com/manchui/domain/controller/ReviewController.java
+++ b/src/main/java/com/manchui/domain/controller/ReviewController.java
@@ -6,6 +6,7 @@ import com.manchui.domain.dto.review.ReviewCreateResponse;
 import com.manchui.domain.dto.review.ReviewDetailPagingResponse;
 import com.manchui.domain.service.ReviewService;
 import com.manchui.global.response.SuccessResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
@@ -15,6 +16,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
+@Tag(name = "Reviews")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/reviews")

--- a/src/main/java/com/manchui/domain/controller/UserController.java
+++ b/src/main/java/com/manchui/domain/controller/UserController.java
@@ -5,6 +5,7 @@ import com.manchui.domain.dto.User.*;
 import com.manchui.domain.entity.User;
 import com.manchui.domain.service.UserService;
 import com.manchui.global.response.SuccessResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
@@ -12,10 +13,14 @@ import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 import java.util.UUID;
 
+@Tag(name = "Users")
 @RestController
 @RequiredArgsConstructor
 public class UserController {
@@ -33,7 +38,7 @@ public class UserController {
 
     @PutMapping("/api/auths/user")
     public ResponseEntity<SuccessResponse<UserEditInfoResponse>> editUserInfo(@AuthenticationPrincipal CustomUserDetails userDetails,
-                                                          @ModelAttribute @Valid UserEditInfoRequest userEditInfoRequest) {
+                                                                              @ModelAttribute @Valid UserEditInfoRequest userEditInfoRequest) {
 
         String userEmail = userDetails.getUsername();
         userService.checkName(userEditInfoRequest.getName());

--- a/src/main/java/com/manchui/domain/dto/gathering/GatheringCursorPagingResponse.java
+++ b/src/main/java/com/manchui/domain/dto/gathering/GatheringCursorPagingResponse.java
@@ -1,0 +1,25 @@
+package com.manchui.domain.dto.gathering;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class GatheringCursorPagingResponse {
+
+    private int gatheringCount;
+
+    private List<GatheringListResponse> gatheringList;
+
+    private Long nextCursor;
+
+    public GatheringCursorPagingResponse(List<GatheringListResponse> gatheringList, int gatheringCount) {
+
+        this.gatheringList = gatheringList;
+        this.gatheringCount = gatheringCount;
+        this.nextCursor = gatheringList.isEmpty() ? null : gatheringList.get(gatheringList.size() - 1).getGatheringId();
+    }
+
+}

--- a/src/main/java/com/manchui/domain/dto/gathering/GatheringInfoResponse.java
+++ b/src/main/java/com/manchui/domain/dto/gathering/GatheringInfoResponse.java
@@ -39,6 +39,8 @@ public class GatheringInfoResponse {
 
     private int currentUsers;
 
+    private int heartCounts;
+
     private boolean isOpened;
 
     private boolean isCanceled;
@@ -57,7 +59,7 @@ public class GatheringInfoResponse {
 
     private ReviewDetailPagingResponse reviewsList;
 
-    public GatheringInfoResponse(Gathering gathering, String filePath, int currentUsers, boolean isHearted, List<UserInfo> userInfoList, ReviewDetailPagingResponse reviewsList) {
+    public GatheringInfoResponse(Gathering gathering, String filePath, int currentUsers, int heartCounts, boolean isHearted, List<UserInfo> userInfoList, ReviewDetailPagingResponse reviewsList) {
 
         this.gatheringId = gathering.getId();
         this.name = gathering.getUser().getName();
@@ -72,6 +74,7 @@ public class GatheringInfoResponse {
         this.maxUsers = gathering.getMaxUsers();
         this.minUsers = gathering.getMinUsers();
         this.currentUsers = currentUsers;
+        this.heartCounts = heartCounts;
         this.isOpened = gathering.isOpened();
         this.isCanceled = gathering.isCanceled();
         this.isClosed = gathering.isClosed();

--- a/src/main/java/com/manchui/domain/dto/gathering/GatheringListResponse.java
+++ b/src/main/java/com/manchui/domain/dto/gathering/GatheringListResponse.java
@@ -33,6 +33,8 @@ public class GatheringListResponse {
 
     private Long currentUsers;
 
+    private Long heartCounts;
+
     private boolean isOpened;
 
     private boolean isClosed;

--- a/src/main/java/com/manchui/domain/repository/GatheringRepository.java
+++ b/src/main/java/com/manchui/domain/repository/GatheringRepository.java
@@ -2,6 +2,7 @@ package com.manchui.domain.repository;
 
 import com.manchui.domain.entity.Gathering;
 import com.manchui.domain.entity.User;
+import com.manchui.domain.repository.querydsl.GatheringCursorQueryDsl;
 import com.manchui.domain.repository.querydsl.GatheringQueryDsl;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -10,7 +11,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.List;
 import java.util.Optional;
 
-public interface GatheringRepository extends JpaRepository<Gathering, Long>, GatheringQueryDsl {
+public interface GatheringRepository extends JpaRepository<Gathering, Long>, GatheringQueryDsl, GatheringCursorQueryDsl {
 
     Optional<Gathering> findByUserAndGroupName(User user, String groupName);
 

--- a/src/main/java/com/manchui/domain/repository/querydsl/GatheringCursorQueryDsl.java
+++ b/src/main/java/com/manchui/domain/repository/querydsl/GatheringCursorQueryDsl.java
@@ -1,0 +1,13 @@
+package com.manchui.domain.repository.querydsl;
+
+import com.manchui.domain.dto.gathering.GatheringCursorPagingResponse;
+
+public interface GatheringCursorQueryDsl {
+
+    // 비회원 모임 목록 조회 (커서 기반 페이징)
+    GatheringCursorPagingResponse getGatheringListByGuest(Long cursor, int size, String query, String location, String startDate, String endDate, String category, String sort, boolean available);
+
+    // 회원 모임 목록 조회 (커서 기반 페이징)
+    GatheringCursorPagingResponse getGatheringListByUser(String email, Long cursor, int size, String query, String location, String startDate, String endDate, String category, String sort, boolean available);
+
+}

--- a/src/main/java/com/manchui/domain/repository/querydsl/GatheringCursorQueryDslImpl.java
+++ b/src/main/java/com/manchui/domain/repository/querydsl/GatheringCursorQueryDslImpl.java
@@ -22,6 +22,7 @@ import static com.manchui.domain.entity.QGathering.gathering;
 import static com.manchui.domain.entity.QHeart.heart;
 import static com.manchui.domain.entity.QImage.image;
 import static com.manchui.domain.entity.QUser.user;
+import static com.querydsl.jpa.JPAExpressions.select;
 
 @Slf4j
 public class GatheringCursorQueryDslImpl implements GatheringCursorQueryDsl {
@@ -122,6 +123,12 @@ public class GatheringCursorQueryDslImpl implements GatheringCursorQueryDsl {
                                 .where(attendance.gathering.id.eq(gathering.id)
                                         .and(attendance.deletedAt.isNull())),
                         "currentUsers"
+                ),
+                Expressions.as(
+                        select(heart.count())
+                                .from(heart)
+                                .where(heart.gathering.id.eq(gathering.id)),
+                        "heartCounts"
                 ),
                 gathering.isOpened,
                 gathering.isClosed,

--- a/src/main/java/com/manchui/domain/repository/querydsl/GatheringCursorQueryDslImpl.java
+++ b/src/main/java/com/manchui/domain/repository/querydsl/GatheringCursorQueryDslImpl.java
@@ -1,0 +1,179 @@
+package com.manchui.domain.repository.querydsl;
+
+import com.manchui.domain.dto.gathering.GatheringCursorPagingResponse;
+import com.manchui.domain.dto.gathering.GatheringListResponse;
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.ConstructorExpression;
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.jpa.JPAExpressions;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import lombok.extern.slf4j.Slf4j;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static com.manchui.domain.entity.QAttendance.attendance;
+import static com.manchui.domain.entity.QGathering.gathering;
+import static com.manchui.domain.entity.QHeart.heart;
+import static com.manchui.domain.entity.QImage.image;
+import static com.manchui.domain.entity.QUser.user;
+
+@Slf4j
+public class GatheringCursorQueryDslImpl implements GatheringCursorQueryDsl {
+
+    private static final String DEFAULT_SORT_FIELD = "createdAt";
+    private final JPAQueryFactory queryFactory;
+
+    public GatheringCursorQueryDslImpl(EntityManager em) {
+
+        this.queryFactory = new JPAQueryFactory(em);
+    }
+
+    @Override
+    public GatheringCursorPagingResponse getGatheringListByGuest(Long cursor, int size, String query, String location, String startDate, String endDate, String category, String sort, boolean available) {
+
+        return getGatheringList(null, cursor, size, query, location, startDate, endDate, category, sort, available);
+    }
+
+    @Override
+    public GatheringCursorPagingResponse getGatheringListByUser(String email, Long cursor, int size, String query, String location, String startDate, String endDate, String category, String sort, boolean available) {
+
+        return getGatheringList(email, cursor, size, query, location, startDate, endDate, category, sort, available);
+    }
+
+    private GatheringCursorPagingResponse getGatheringList(String email, Long cursor, int size, String query, String location, String startDate, String endDate, String category, String sort, boolean available) {
+
+        updateIsClosedStatus();
+
+        log.info("{} 모임 목록 조회 요청", (email != null) ? email : "비회원");
+
+        String sortField = (sort == null) ? DEFAULT_SORT_FIELD : sort;
+
+        // 커서 조건을 제외한 기본 조건 빌더
+        BooleanBuilder baseConditions = new BooleanBuilder()
+                .and(buildFilterConditions(query, location, startDate, endDate, category));
+
+        if (available) {
+            baseConditions.and(gathering.maxUsers.gt(
+                    JPAExpressions
+                            .select(attendance.count())
+                            .from(attendance)
+                            .where(attendance.gathering.id.eq(gathering.id)
+                                    .and(attendance.deletedAt.isNull()))
+            ));
+        }
+
+        // 1. 목록 조회 쿼리 (커서 조건 포함)
+        BooleanBuilder listConditions = new BooleanBuilder(baseConditions);
+        if (cursor != null) {
+            listConditions.and(gathering.id.lt(cursor));
+        }
+
+        List<GatheringListResponse> gatheringList = queryFactory
+                .select(buildGatheringListProjection(email))
+                .from(gathering)
+                .leftJoin(gathering.user, user)
+                .where(listConditions)
+                .orderBy(sortField.equals("closeDate") ? gathering.dueDate.asc() : gathering.createdAt.desc())
+                .limit(size)
+                .fetch();
+
+        // 2. 전체 개수 조회 쿼리 (커서 조건 제외)
+        long gatheringCount = Optional.ofNullable(
+                queryFactory
+                        .select(gathering.count())
+                        .from(gathering)
+                        .where(baseConditions)
+                        .fetchOne()
+        ).orElse(0L);
+
+        return new GatheringCursorPagingResponse(gatheringList, (int) gatheringCount);
+    }
+
+
+    private ConstructorExpression<GatheringListResponse> buildGatheringListProjection(String email) {
+
+        return Projections.constructor(
+                GatheringListResponse.class,
+                user.name.as("name"),
+                user.profileImagePath.as("profileImage"),
+                gathering.id.as("gatheringId"),
+                gathering.groupName,
+                gathering.category,
+                gathering.location,
+                Expressions.as(
+                        queryFactory.select(image.filePath)
+                                .from(image)
+                                .where(image.gatheringId.eq(gathering.id)),
+                        "gatheringImage"
+                ),
+                gathering.gatheringDate,
+                gathering.dueDate,
+                gathering.maxUsers,
+                gathering.minUsers,
+                Expressions.as(
+                        queryFactory.select(attendance.count())
+                                .from(attendance)
+                                .where(attendance.gathering.id.eq(gathering.id)
+                                        .and(attendance.deletedAt.isNull())),
+                        "currentUsers"
+                ),
+                gathering.isOpened,
+                gathering.isClosed,
+                gathering.createdAt,
+                gathering.updatedAt,
+                gathering.deletedAt,
+                Expressions.as(
+                        queryFactory.select(heart.count())
+                                .from(heart)
+                                .where(
+                                        heart.gathering.id.eq(gathering.id)
+                                                .and(email != null ? heart.user.email.eq(email) : null)
+                                ).gt(0L),
+                        "isHearted"
+                )
+        );
+    }
+
+    private BooleanExpression buildFilterConditions(String query, String location, String startDate, String endDate, String category) {
+
+        BooleanExpression condition = gathering.isCanceled.eq(false).and(gathering.isClosed.eq(false));
+
+        if (query != null && !query.isEmpty()) {
+            condition = condition.and(gathering.groupName.contains(query));
+        }
+
+        if (location != null && !location.isEmpty()) {
+            condition = condition.and(gathering.location.contains(location));
+        }
+
+        if (startDate != null && !startDate.isEmpty() && endDate != null && !endDate.isEmpty()) {
+            LocalDate start = LocalDate.parse(startDate);
+            LocalDate end = LocalDate.parse(endDate);
+            condition = condition.and(gathering.gatheringDate.between(start.atStartOfDay(), end.atTime(23, 59, 59)));
+        }
+
+        if (category != null && !category.isEmpty()) {
+            condition = condition.and(gathering.category.eq(category));
+        }
+
+        return condition;
+    }
+
+    private void updateIsClosedStatus() {
+
+        long updatedCount = queryFactory.update(gathering)
+                .set(gathering.isClosed, true)
+                .where(gathering.dueDate.before(LocalDateTime.now())
+                        .and(gathering.isClosed.eq(false)))
+                .execute();
+
+        log.info("모임의 isClosed 상태가 {} 번 업데이트되었습니다.", updatedCount);
+    }
+
+}

--- a/src/main/java/com/manchui/domain/repository/querydsl/GatheringQueryDsl.java
+++ b/src/main/java/com/manchui/domain/repository/querydsl/GatheringQueryDsl.java
@@ -6,10 +6,6 @@ import org.springframework.data.domain.Pageable;
 
 public interface GatheringQueryDsl {
 
-    Page<GatheringListResponse> getGatheringListByGuest(Pageable pageable, String query, String location, String startDate, String endDate, String category, String sort, boolean available);
-
-    Page<GatheringListResponse> getGatheringListByUser(String email, Pageable pageable, String query, String location, String startDate, String endDate, String category, String sort, boolean available);
-
     Page<GatheringListResponse> getHeartList(String email, Pageable pageable, String query, String location, String startDate, String endDate, String category, String sort, boolean available);
 
 }

--- a/src/main/java/com/manchui/domain/repository/querydsl/GatheringQueryDslImpl.java
+++ b/src/main/java/com/manchui/domain/repository/querydsl/GatheringQueryDslImpl.java
@@ -137,6 +137,12 @@ public class GatheringQueryDslImpl implements GatheringQueryDsl {
                                                 .and(attendance.deletedAt.isNull())),
                                 "currentUsers"
                         ),
+                        Expressions.as(
+                                select(heart.count())
+                                        .from(heart)
+                                        .where(heart.gathering.id.eq(gathering.id)),
+                                "heartCounts"
+                        ),
                         gathering.isOpened,
                         gathering.isClosed,
                         gathering.createdAt,

--- a/src/main/java/com/manchui/domain/repository/querydsl/GatheringQueryDslImpl.java
+++ b/src/main/java/com/manchui/domain/repository/querydsl/GatheringQueryDslImpl.java
@@ -34,70 +34,85 @@ public class GatheringQueryDslImpl implements GatheringQueryDsl {
         this.queryFactory = new JPAQueryFactory(em);
     }
 
-    // 비회원 모임 목록 조회
-    @Override
-    public Page<GatheringListResponse> getGatheringListByGuest(Pageable pageable, String query, String location, String startDate, String endDate, String category, String sort, boolean available) {
-
-        return getGatheringList(null, pageable, query, location, startDate, endDate, category, sort, available);
-    }
-
-    // 회원 모임 목록 조회
-    @Override
-    public Page<GatheringListResponse> getGatheringListByUser(String email, Pageable pageable, String query, String location, String startDate, String endDate, String category, String sort, boolean available) {
-
-        return getGatheringList(email, pageable, query, location, startDate, endDate, category, sort, available);
-    }
-
-    // 찜한 모임 목록 조회
     @Override
     public Page<GatheringListResponse> getHeartList(String email, Pageable pageable, String query, String location, String startDate, String endDate, String category, String sort, boolean available) {
 
-        return getGatheringList(email, pageable, query, location, startDate, endDate, category, sort, true, available);
+        return getHeartGatheringList(email, pageable, query, location, startDate, endDate, category, sort, available);
     }
 
-    // 공통 모임 목록 조회 로직
-    private Page<GatheringListResponse> getGatheringList(String email, Pageable pageable, String query, String location, String startDate, String endDate, String category, String sort, boolean available) {
-
-        return getGatheringList(email, pageable, query, location, startDate, endDate, category, sort, false, available);
-    }
-
-    // Gathering 목록 쿼리를 수행하고 필터를 적용하는 메서드
-    private Page<GatheringListResponse> getGatheringList(String email, Pageable pageable, String query, String location, String startDate, String endDate, String category, String sort, boolean isHeartList, boolean available) {
-
-        updateIsClosedStatus(); // 상태 업데이트
-        JPAQuery<GatheringListResponse> queryBuilder = buildBaseQuery(email, isHeartList, available);
-        applyFilters(queryBuilder, query, location, startDate, endDate, category, sort);
-
-        // dueDate 체크: 이 조건은 이미 상태 업데이트 로직에서 처리됨
-        queryBuilder.where(gathering.dueDate.after(LocalDateTime.now()));
-
-        // 찜한 모임의 경우, 찜한 모임만 필터링
-        if (isHeartList) {
-            queryBuilder.where(heart.user.email.eq(email)); // 찜한 모임만 조회
-        }
-
-        return executePagedQuery(queryBuilder, pageable);
-    }
-
-    // 요청 시점에 dueDate가 지난 모임의 isClosed 상태 업데이트
+    // dueDate가 지난 모임의 isClosed 상태 업데이트
     private void updateIsClosedStatus() {
 
         long updatedCount = queryFactory.update(gathering)
                 .set(gathering.isClosed, true)
                 .where(gathering.dueDate.before(LocalDateTime.now())
-                        .and(gathering.isClosed.eq(false)))  // isClosed가 false인 경우만 업데이트
+                        .and(gathering.isClosed.eq(false)))
                 .execute();
 
-        // 상태 업데이트 로그
-        log.info("모임의 isClosed 상태가 {} 번 업데이트되었습니다.", updatedCount);
+        log.info("모임의 isClosed 상태가 {}번 업데이트되었습니다.", updatedCount);
     }
 
-    // 공통 쿼리
-    private JPAQuery<GatheringListResponse> buildBaseQuery(String email, boolean isHeartList, boolean available) {
+    // Gathering 목록 쿼리를 수행하고 필터를 적용하는 메서드
+    private Page<GatheringListResponse> getHeartGatheringList(String email, Pageable pageable, String query, String location, String startDate, String endDate, String category, String sort, boolean available) {
 
-        log.info("{}가 요청한 모임 목록 조회 공통 쿼리 실행 ", email);
+        updateIsClosedStatus();
 
-        JPAQuery<GatheringListResponse> query = queryFactory
+        JPAQuery<GatheringListResponse> queryBuilder = buildHeartGatheringQuery(email);
+        applyFilters(queryBuilder, query, location, startDate, endDate, category, sort);
+
+        // 참여 가능한 모임만 조회
+        if (available) {
+            queryBuilder.where(gathering.maxUsers.gt(
+                    select(attendance.count())
+                            .from(attendance)
+                            .where(attendance.gathering.id.eq(gathering.id)
+                                    .and(attendance.deletedAt.isNull()))
+            ));
+        }
+
+        // dueDate 체크: 이 조건은 이미 상태 업데이트 로직에서 처리됨
+        queryBuilder.where(gathering.dueDate.after(LocalDateTime.now()));
+
+        // 찜한 모임만 필터링
+        queryBuilder.where(heart.user.email.eq(email));
+
+        return executePagedQuery(queryBuilder, pageable);
+    }
+
+    // 필터링 적용
+    private void applyFilters(JPAQuery<GatheringListResponse> queryBuilder, String query, String location, String startDate, String endDate, String category, String sort) {
+
+        if (StringUtils.hasText(query)) {
+            queryBuilder.where(gathering.groupName.contains(query));
+        }
+
+        if (StringUtils.hasText(location)) {
+            queryBuilder.where(gathering.location.contains(location));
+        }
+
+        if (StringUtils.hasText(startDate) && StringUtils.hasText(endDate)) {
+            LocalDate start = LocalDate.parse(startDate);
+            LocalDate end = LocalDate.parse(endDate);
+            queryBuilder.where(gathering.gatheringDate.between(start.atStartOfDay(), end.atTime(23, 59, 59)));
+        }
+
+        if (StringUtils.hasText(category)) {
+            queryBuilder.where(gathering.category.eq(category));
+        }
+
+        // 정렬 조건 적용
+        if ("closeDate".equals(sort)) {
+            queryBuilder.orderBy(gathering.dueDate.asc());
+        } else {
+            queryBuilder.orderBy(gathering.createdAt.desc());
+        }
+    }
+
+    private JPAQuery<GatheringListResponse> buildHeartGatheringQuery(String email) {
+
+        log.info("{}가 요청한 찜한 모임 목록 조회 쿼리 실행", email);
+
+        return queryFactory
                 .select(Projections.constructor(GatheringListResponse.class,
                         user.name.as("name"),
                         user.profileImagePath.as("profileImage"),
@@ -127,7 +142,7 @@ public class GatheringQueryDslImpl implements GatheringQueryDsl {
                         gathering.createdAt,
                         gathering.updatedAt,
                         gathering.deletedAt,
-                        (email != null ? Expressions.as(
+                        Expressions.as(
                                 select(heart.count())
                                         .from(heart)
                                         .where(
@@ -135,59 +150,16 @@ public class GatheringQueryDslImpl implements GatheringQueryDsl {
                                                         .and(heart.gathering.id.eq(gathering.id))
                                         ).gt(0L),
                                 "isHearted"
-                        ) : Expressions.constant(false))
+                        )
                 ))
                 .from(gathering)
                 .leftJoin(gathering.user, user)
+                .leftJoin(heart).on(heart.gathering.id.eq(gathering.id)
+                        .and(heart.user.email.eq(email)))
                 .where(gathering.isCanceled.eq(false)
                         .and(gathering.isClosed.eq(false)));
-
-        if (isHeartList) {
-            query.leftJoin(heart).on(heart.gathering.id.eq(gathering.id)
-                    .and(heart.user.email.eq(email)));
-        }
-
-        // 참여 가능한 모임만 조회
-        if (available) {
-            query.where(gathering.maxUsers.gt(
-                    select(attendance.count())
-                            .from(attendance)
-                            .where(attendance.gathering.id.eq(gathering.id)
-                                    .and(attendance.deletedAt.isNull()))
-            ));
-        }
-
-        return query;
     }
 
-    // 필터링 적용
-    private void applyFilters(JPAQuery<GatheringListResponse> queryBuilder, String query, String location, String startDate, String endDate, String category, String sort) {
-
-        if (StringUtils.hasText(query)) {
-            queryBuilder.where(gathering.groupName.contains(query));
-        }
-
-        if (StringUtils.hasText(location)) {
-            queryBuilder.where(gathering.location.contains(location));
-        }
-
-        if (startDate != null && !startDate.isEmpty() && endDate != null && !endDate.isEmpty()) {
-            LocalDate start = LocalDate.parse(startDate);
-            LocalDate end = LocalDate.parse(endDate);
-            queryBuilder.where(gathering.gatheringDate.between(start.atStartOfDay(), end.atTime(23, 59, 59)));
-        }
-
-        if (StringUtils.hasText(category)) {
-            queryBuilder.where(gathering.category.contains(category));
-        }
-
-        // 정렬 조건 적용
-        if ("closeDate".equals(sort)) {
-            queryBuilder.orderBy(gathering.dueDate.asc());
-        } else {
-            queryBuilder.orderBy(gathering.createdAt.desc());
-        }
-    }
 
     // 페이징 처리된 쿼리 결과를 실행하는 메서드
     private Page<GatheringListResponse> executePagedQuery(JPAQuery<GatheringListResponse> queryBuilder, Pageable pageable) {
@@ -197,18 +169,23 @@ public class GatheringQueryDslImpl implements GatheringQueryDsl {
                 .limit(pageable.getPageSize())
                 .fetch();
 
-        // 카운트 쿼리
-        long total = Optional.ofNullable(
+        log.info("조회된 모임의 수: {}", gatheringList.size());
+
+        long total = fetchTotalCount(queryBuilder);
+
+        return new PageImpl<>(gatheringList, pageable, total);
+    }
+
+    // 전체 데이터 개수 조회 메서드
+    private long fetchTotalCount(JPAQuery<GatheringListResponse> queryBuilder) {
+
+        return Optional.ofNullable(
                 queryBuilder.clone()
-                        .offset(0)  // 페이지네이션 제거
-                        .limit(Long.MAX_VALUE) // 페이지 제한 제거
+                        .offset(0)
+                        .limit(Long.MAX_VALUE)
                         .select(gathering.count())
                         .fetchOne()
         ).orElse(0L);
-
-        log.info("조회된 모임의 수 : {}", total);
-
-        return new PageImpl<>(gatheringList, pageable, total);
     }
 
 }

--- a/src/main/java/com/manchui/domain/service/GatheringService.java
+++ b/src/main/java/com/manchui/domain/service/GatheringService.java
@@ -1,10 +1,7 @@
 package com.manchui.domain.service;
 
 import com.manchui.domain.dto.CustomUserDetails;
-import com.manchui.domain.dto.gathering.GatheringCreateRequest;
-import com.manchui.domain.dto.gathering.GatheringCreateResponse;
-import com.manchui.domain.dto.gathering.GatheringInfoResponse;
-import com.manchui.domain.dto.gathering.GatheringPagingResponse;
+import com.manchui.domain.dto.gathering.*;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
@@ -13,7 +10,7 @@ public interface GatheringService {
 
     GatheringCreateResponse createGathering(String email, GatheringCreateRequest createRequest);
 
-    GatheringPagingResponse getGatherings(CustomUserDetails userDetails, Pageable pageable, String query, String location, String startDate, String endDate, String category, String sort, boolean available);
+    GatheringCursorPagingResponse getGatherings(CustomUserDetails userDetails, Long cursor, int size, String query, String location, String startDate, String endDate, String category, String sort, boolean available);
 
     void joinGathering(String email, Long gatheringId);
 

--- a/src/main/java/com/manchui/domain/service/GatheringServiceImpl.java
+++ b/src/main/java/com/manchui/domain/service/GatheringServiceImpl.java
@@ -363,9 +363,13 @@ public class GatheringServiceImpl implements GatheringService {
         int currentUsers = userInfoList.size();
         log.info("현재 모임 id {}의 참여자 수: {}", gatheringId, currentUsers);
 
+        List<Heart> byGathering = heartRepository.findByGathering(gathering);
+
+        int heartCounts = byGathering.size();
+
         boolean isHearted = isUser && heartRepository.findByUserAndGathering(user, gathering).isPresent();
 
-        return new GatheringInfoResponse(gathering, image.getFilePath(), currentUsers, isHearted, userInfoList, reviewsList);
+        return new GatheringInfoResponse(gathering, image.getFilePath(), currentUsers, heartCounts, isHearted, userInfoList, reviewsList);
     }
 
     // 상세 조회 후기 관련 응답 객체 생성

--- a/src/main/java/com/manchui/global/config/SwaggerConfig.java
+++ b/src/main/java/com/manchui/global/config/SwaggerConfig.java
@@ -3,6 +3,7 @@ package com.manchui.global.config;
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.tags.Tag;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -14,7 +15,12 @@ public class SwaggerConfig {
 
         return new OpenAPI()
                 .components(new Components())
-                .info(apiInfo());
+                .info(apiInfo())
+                .addTagsItem(new Tag().name("Join").description("회원가입 관련 API"))
+                .addTagsItem(new Tag().name("Users").description("사용자 관련 API"))
+                .addTagsItem(new Tag().name("Gatherings").description("모임 관련 API"))
+                .addTagsItem(new Tag().name("Reviews").description("후기 관련 API"))
+                .addTagsItem(new Tag().name("Token").description("토큰 관련 API"));
     }
 
     private Info apiInfo() {
@@ -24,4 +30,5 @@ public class SwaggerConfig {
                 .description("만 명이 즐기는 취미(만취)의 API 서버입니다.")
                 .version("1.0");
     }
+
 }

--- a/src/main/java/com/manchui/global/jwt/JWTFilter.java
+++ b/src/main/java/com/manchui/global/jwt/JWTFilter.java
@@ -39,7 +39,10 @@ public class JWTFilter extends OncePerRequestFilter {
         if ((requestUri.matches("^\\/api\\/auths\\/signup$") && requestMethod.equals("POST")) ||
                 (requestUri.matches("^\\/api\\/auths\\/check-name$") && requestMethod.equals("POST")) ||
                 (requestUri.matches("^\\/api\\/auths\\/signin$") && requestMethod.equals("POST")) ||
-                (requestUri.matches("^\\/api\\/reviews$") && requestMethod.equals("GET"))) {
+                (requestUri.matches("^\\/api\\/reviews$") && requestMethod.equals("GET")) ||
+                (requestUri.matches("^/swagger-ui(/.*)?$")) ||
+                (requestUri.matches("^/swagger-ui.html$")) ||
+                (requestUri.matches("^/v3/api-docs(?:/.*)?$"))) {
             filterChain.doFilter(request, response);
             return;
         }
@@ -50,7 +53,6 @@ public class JWTFilter extends OncePerRequestFilter {
 
         // /api/gatherings/public/** 요청에 대한 처리
         if (requestUri.matches("^/api/gatherings/public.*$") && requestMethod.equals("GET")) {
-            log.info("모임 전체 목록 조회 요청");
             // 토큰이 없는 경우 비회원으로 처리
             if (authorization == null || !authorization.startsWith("Bearer ")) {
                 filterChain.doFilter(request, response);


### PR DESCRIPTION
## #️⃣ Issue Number

<!--- ex) #이슈번호, #이슈번호 -->
#73 

## 📝 요약(Summary)

<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

- 프론트엔드 무한 스크롤 구현 시 데이터 중복 및 누락 문제를 해결하기 위해, 모임 목록 조회 방식을 오프셋 기반 페이지네이션에서 커서 기반 페이지네이션으로 변경
- 코드 가독성을 높이기 위해, 찜한 모임 조회와 모임 목록 조회 클래스를 분리
- Swagger 화면에서 각 그룹별 메서드 조회가 가능하도록 Tag 설정 추가
- Swagger 화면 조회를 위해 JWTFilter 클래스에 허용 경로 추가

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [X] 새로운 기능 추가
- [X] 코드 리팩토링
- [X] 주석 추가 및 수정
- [X] 파일 혹은 폴더명 수정
