### PR TITLE
[Refactor] 모임 재생성 기능 보완

### DIFF
--- a/src/main/java/com/manchui/domain/controller/GatheringController.java
+++ b/src/main/java/com/manchui/domain/controller/GatheringController.java
@@ -118,35 +118,20 @@ public class GatheringController {
         return ResponseEntity.ok().body(SuccessResponse.successWithNoData("모임에 누른 좋아요가 취소되었습니다."));
     }
 
-    @Operation(summary = "모임 상세 조회 (비회원)", description = "비회원이 요청하는 모임의 상세 내용을 반환합니다.")
+    @Operation(summary = "모임 상세 조회", description = "회원 및 비회원이 요청하는 모임의 상세 내용을 반환합니다.")
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "비회원이 요청한 모임의 상세 내용이 반환되었습니다.",
+            @ApiResponse(responseCode = "200", description = "요청한 모임의 상세 내용이 반환되었습니다.",
                     content = @Content(mediaType = "application/json")),
             @ApiResponse(responseCode = "404", description = "해당하는 모임이 없습니다.")
     })
     @GetMapping("/public/{gatheringId}/reviews")
-    public ResponseEntity<SuccessResponse<GatheringInfoResponse>> getGatheringInfoByGuest(@PathVariable Long gatheringId,
-                                                                                          @RequestParam(defaultValue = "1") int page,
-                                                                                          @RequestParam int size) {
+    public ResponseEntity<SuccessResponse<GatheringInfoResponse>> getGatheringInfo(@AuthenticationPrincipal CustomUserDetails userDetails,
+                                                                                   @PathVariable Long gatheringId,
+                                                                                   @RequestParam(defaultValue = "1") int page,
+                                                                                   @RequestParam int size) {
 
         Pageable pageable = PageRequest.of(page - 1, size, Sort.by("createdAt").descending());
-        return ResponseEntity.ok(SuccessResponse.successWithData(gatheringService.getGatheringInfoByGuest(gatheringId, pageable)));
-    }
-
-    @Operation(summary = "모임 상세 조회 (회원)", description = "회원이 요청하는 모임의 상세 내용을 반환합니다.")
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "회원이 요청한 모임의 상세 내용이 반환되었습니다.",
-                    content = @Content(mediaType = "application/json")),
-            @ApiResponse(responseCode = "404", description = "해당하는 모임이 없습니다.")
-    })
-    @GetMapping("/{gatheringId}/reviews")
-    public ResponseEntity<SuccessResponse<GatheringInfoResponse>> getGatheringInfoByUser(@AuthenticationPrincipal CustomUserDetails userDetails,
-                                                                                         @PathVariable Long gatheringId,
-                                                                                         @RequestParam(defaultValue = "1") int page,
-                                                                                         @RequestParam int size) {
-
-        Pageable pageable = PageRequest.of(page - 1, size, Sort.by("createdAt").descending());
-        return ResponseEntity.ok(SuccessResponse.successWithData(gatheringService.getGatheringInfoByUser(userDetails.getUsername(), gatheringId, pageable)));
+        return ResponseEntity.ok(SuccessResponse.successWithData(gatheringService.getGatheringInfo(userDetails, gatheringId, pageable)));
     }
 
     @Operation(summary = "모임 취소", description = "모임을 취소합니다.")

--- a/src/main/java/com/manchui/domain/controller/GatheringController.java
+++ b/src/main/java/com/manchui/domain/controller/GatheringController.java
@@ -170,4 +170,17 @@ public class GatheringController {
         return ResponseEntity.ok(SuccessResponse.successWithData(gatheringService.getHeartList(userDetails.getUsername(), pageable, query, location, startDate, endDate, category, sort, available)));
     }
 
+
+    @Operation(summary = "마감된 모임 목록 조회", description = "회원이 생성한 모임 중 마감된 모임 목록을 반환합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "회원의 모임 중 마감된 모임 목록입니다.",
+                    content = @Content(mediaType = "application/json")),
+            @ApiResponse(responseCode = "200", description = "마감된 모임이 존재하지 않습니다.")
+    })
+    @GetMapping("")
+    public ResponseEntity<SuccessResponse<ClosedGatheringResponse>> getClosedGathering(@AuthenticationPrincipal CustomUserDetails userDetails) {
+
+        return ResponseEntity.ok(SuccessResponse.successWithData(gatheringService.getClosedGathering(userDetails.getUsername())));
+    }
+
 }

--- a/src/main/java/com/manchui/domain/controller/GatheringController.java
+++ b/src/main/java/com/manchui/domain/controller/GatheringController.java
@@ -183,4 +183,11 @@ public class GatheringController {
         return ResponseEntity.ok(SuccessResponse.successWithData(gatheringService.getClosedGathering(userDetails.getUsername())));
     }
 
+    @GetMapping("/{gatheringId}")
+    public ResponseEntity<SuccessResponse<ClosedGatheringInfoResponse>> getClosedGatheringInfo(@AuthenticationPrincipal CustomUserDetails userDetails,
+                                                                                               @PathVariable Long gatheringId) {
+
+        return ResponseEntity.ok(SuccessResponse.successWithData(gatheringService.getClosedGatheringInfo(userDetails.getUsername(), gatheringId)));
+    }
+
 }

--- a/src/main/java/com/manchui/domain/controller/GatheringController.java
+++ b/src/main/java/com/manchui/domain/controller/GatheringController.java
@@ -183,6 +183,12 @@ public class GatheringController {
         return ResponseEntity.ok(SuccessResponse.successWithData(gatheringService.getClosedGathering(userDetails.getUsername())));
     }
 
+    @Operation(summary = "마감된 모임 상세 조회", description = "회원이 생성한 모임 중 마감된 모임의 상세 내용을 반환합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "회원의 모임 중 마감된 모임의 상세 내용입니다.",
+                    content = @Content(mediaType = "application/json")),
+            @ApiResponse(responseCode = "400", description = "본인의 모임만 관리가 가능합니다.")
+    })
     @GetMapping("/{gatheringId}")
     public ResponseEntity<SuccessResponse<ClosedGatheringInfoResponse>> getClosedGatheringInfo(@AuthenticationPrincipal CustomUserDetails userDetails,
                                                                                                @PathVariable Long gatheringId) {

--- a/src/main/java/com/manchui/domain/dto/gathering/ClosedGathering.java
+++ b/src/main/java/com/manchui/domain/dto/gathering/ClosedGathering.java
@@ -1,0 +1,14 @@
+package com.manchui.domain.dto.gathering;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ClosedGathering {
+
+    private Long gatheringId;
+
+    private String groupName;
+
+}

--- a/src/main/java/com/manchui/domain/dto/gathering/ClosedGatheringInfoResponse.java
+++ b/src/main/java/com/manchui/domain/dto/gathering/ClosedGatheringInfoResponse.java
@@ -1,0 +1,30 @@
+package com.manchui.domain.dto.gathering;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ClosedGatheringInfoResponse {
+
+    private Long gatheringId;
+
+    private String groupName;
+
+    private String category;
+
+    private String location;
+
+    private String gatheringImage;
+
+    private String content;
+
+    private int maxUsers;
+
+    private int minUsers;
+
+}

--- a/src/main/java/com/manchui/domain/dto/gathering/ClosedGatheringResponse.java
+++ b/src/main/java/com/manchui/domain/dto/gathering/ClosedGatheringResponse.java
@@ -1,0 +1,16 @@
+package com.manchui.domain.dto.gathering;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class ClosedGatheringResponse {
+
+    private int gatheringCount;
+
+    private List<ClosedGathering> closedGatheringList;
+
+}

--- a/src/main/java/com/manchui/domain/dto/gathering/GatheringCreateRequest.java
+++ b/src/main/java/com/manchui/domain/dto/gathering/GatheringCreateRequest.java
@@ -39,7 +39,8 @@ public class GatheringCreateRequest {
     @Max(100)
     private int minUsers;
 
-    @Size(min = 10, max = 255)
+    @NotBlank(message = "모임 설명은 필수 입력 값입니다.")
+    @Size(min = 10, max = 1000, message = "모임 내용은 10자 이상 1000자 이하로 입력해주세요.")
     private String gatheringContent;
 
     public Gathering toRegisterEntity(User user, LocalDateTime gatheringDate, LocalDateTime dueDate) {

--- a/src/main/java/com/manchui/domain/entity/Gathering.java
+++ b/src/main/java/com/manchui/domain/entity/Gathering.java
@@ -1,5 +1,6 @@
 package com.manchui.domain.entity;
 
+import com.manchui.domain.dto.gathering.ClosedGatheringInfoResponse;
 import com.manchui.domain.dto.gathering.GatheringCreateResponse;
 import com.manchui.global.entity.Timestamped;
 import jakarta.persistence.*;
@@ -135,6 +136,20 @@ public class Gathering extends Timestamped {
         this.minUsers = minUsers;
         this.gatheringContent = gatheringContent;
 
+    }
+
+    public ClosedGatheringInfoResponse toClosedResponseDto(String gatheringImage) {
+
+        return ClosedGatheringInfoResponse.builder()
+                .gatheringId(id)
+                .groupName(groupName)
+                .category(category)
+                .location(location)
+                .gatheringImage(gatheringImage)
+                .content(getGatheringContent())
+                .maxUsers(maxUsers)
+                .minUsers(minUsers)
+                .build();
     }
 
 }

--- a/src/main/java/com/manchui/domain/repository/GatheringRepository.java
+++ b/src/main/java/com/manchui/domain/repository/GatheringRepository.java
@@ -19,4 +19,6 @@ public interface GatheringRepository extends JpaRepository<Gathering, Long>, Gat
 
     Page<Gathering> findByIdIn(List<Long> gatheringIdList, Pageable pageable);
 
+    List<Gathering> findByUserAndIsClosedAndIsCanceled(User user, boolean isClosed, boolean isCanceled);
+
 }

--- a/src/main/java/com/manchui/domain/repository/querydsl/GatheringCursorQueryDslImpl.java
+++ b/src/main/java/com/manchui/domain/repository/querydsl/GatheringCursorQueryDslImpl.java
@@ -97,7 +97,7 @@ public class GatheringCursorQueryDslImpl implements GatheringCursorQueryDsl {
     }
 
     private ConstructorExpression<GatheringListResponse> buildGatheringListProjection(String email) {
-        
+
         return Projections.constructor(
                 GatheringListResponse.class,
                 user.name.as("name"),

--- a/src/main/java/com/manchui/domain/repository/querydsl/GatheringCursorQueryDslImpl.java
+++ b/src/main/java/com/manchui/domain/repository/querydsl/GatheringCursorQueryDslImpl.java
@@ -96,8 +96,9 @@ public class GatheringCursorQueryDslImpl implements GatheringCursorQueryDsl {
         return new GatheringCursorPagingResponse(gatheringList, (int) gatheringCount);
     }
 
-
     private ConstructorExpression<GatheringListResponse> buildGatheringListProjection(String email) {
+
+        log.info("사용자 email : {}", email);
 
         return Projections.constructor(
                 GatheringListResponse.class,
@@ -140,7 +141,11 @@ public class GatheringCursorQueryDslImpl implements GatheringCursorQueryDsl {
                                 .from(heart)
                                 .where(
                                         heart.gathering.id.eq(gathering.id)
-                                                .and(email != null ? heart.user.email.eq(email) : null)
+                                                .and(
+                                                        email != null
+                                                                ? heart.user.email.eq(email)
+                                                                : heart.user.email.isNull()
+                                                )
                                 ).gt(0L),
                         "isHearted"
                 )

--- a/src/main/java/com/manchui/domain/repository/querydsl/GatheringCursorQueryDslImpl.java
+++ b/src/main/java/com/manchui/domain/repository/querydsl/GatheringCursorQueryDslImpl.java
@@ -97,9 +97,7 @@ public class GatheringCursorQueryDslImpl implements GatheringCursorQueryDsl {
     }
 
     private ConstructorExpression<GatheringListResponse> buildGatheringListProjection(String email) {
-
-        log.info("사용자 email : {}", email);
-
+        
         return Projections.constructor(
                 GatheringListResponse.class,
                 user.name.as("name"),

--- a/src/main/java/com/manchui/domain/service/GatheringReader.java
+++ b/src/main/java/com/manchui/domain/service/GatheringReader.java
@@ -21,4 +21,6 @@ public interface GatheringReader {
 
     Gathering checkGatheringStatusIsCanceled(Long gatheringId);
 
+    List<Gathering> findClosedGathering(User user);
+
 }

--- a/src/main/java/com/manchui/domain/service/GatheringReaderImpl.java
+++ b/src/main/java/com/manchui/domain/service/GatheringReaderImpl.java
@@ -89,5 +89,17 @@ public class GatheringReaderImpl implements GatheringReader {
         return gathering;
     }
 
+    @Override
+    public List<Gathering> findClosedGathering(User user) {
+
+        // 유저가 생성한 모임 중 마감되었으면서 취소되지 않고 실제 모임 날짜도 지난 상태의 모임만 조회
+        List<Gathering> gatherings = gatheringRepository.findByUserAndIsClosedAndIsCanceled(user, true, false);
+
+        // 추가 조건으로 필터링
+        return gatherings.stream()
+                .filter(gathering -> gathering.getGatheringDate().isBefore(LocalDateTime.now()))
+                .toList();
+    }
+
 
 }

--- a/src/main/java/com/manchui/domain/service/GatheringService.java
+++ b/src/main/java/com/manchui/domain/service/GatheringService.java
@@ -20,9 +20,7 @@ public interface GatheringService {
 
     void heartCancelGathering(String email, Long gatheringId);
 
-    GatheringInfoResponse getGatheringInfoByGuest(Long gatheringId, Pageable pageable);
-
-    GatheringInfoResponse getGatheringInfoByUser(String email, Long gatheringId, Pageable pageable);
+    GatheringInfoResponse getGatheringInfo(CustomUserDetails userDetails, Long gatheringId, Pageable pageable);
 
     void cancelGathering(String email, Long gatheringId);
 

--- a/src/main/java/com/manchui/domain/service/GatheringService.java
+++ b/src/main/java/com/manchui/domain/service/GatheringService.java
@@ -28,4 +28,6 @@ public interface GatheringService {
 
     ClosedGatheringResponse getClosedGathering(String email);
 
+    ClosedGatheringInfoResponse getClosedGatheringInfo(String email, Long gatheringId);
+
 }

--- a/src/main/java/com/manchui/domain/service/GatheringService.java
+++ b/src/main/java/com/manchui/domain/service/GatheringService.java
@@ -26,4 +26,6 @@ public interface GatheringService {
 
     GatheringPagingResponse getHeartList(String email, Pageable pageable, String query, String location, String startDate, String endDate, String category, String sort, boolean available);
 
+    ClosedGatheringResponse getClosedGathering(String email);
+
 }

--- a/src/main/java/com/manchui/domain/service/GatheringServiceImpl.java
+++ b/src/main/java/com/manchui/domain/service/GatheringServiceImpl.java
@@ -338,6 +338,29 @@ public class GatheringServiceImpl implements GatheringService {
         return new GatheringPagingResponse(gatheringRepository.getHeartList(email, pageable, query, location, startDate, endDate, category, sort, available));
     }
 
+    /**
+     * 9. 유저가 생성한 모임 중 마감된 모임 목록 조회
+     * 작성자: 오예령
+     *
+     * @param email 유저 email
+     * @return 해당하는 모임 list 반환
+     */
+    @Override
+    public ClosedGatheringResponse getClosedGathering(String email) {
+
+        User user = userService.checkUser(email);
+
+        List<Gathering> gatheringList = gatheringReader.findClosedGathering(user);
+
+        if (gatheringList.isEmpty()) throw new CustomException(WRITTEN_GATHERING_NOT_EXIST);
+
+        List<ClosedGathering> closedGatheringList = gatheringList.stream()
+                .map(gathering -> new ClosedGathering(gathering.getId(), gathering.getGroupName())
+                ).toList();
+
+        return new ClosedGatheringResponse(gatheringList.size(), closedGatheringList);
+    }
+
     // 참여 여부 판단
     private void handleExistingAttendance(Attendance attendance) {
 

--- a/src/main/java/com/manchui/domain/service/GatheringServiceImpl.java
+++ b/src/main/java/com/manchui/domain/service/GatheringServiceImpl.java
@@ -16,6 +16,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
+import java.nio.charset.StandardCharsets;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
@@ -58,6 +59,12 @@ public class GatheringServiceImpl implements GatheringService {
     @Override
     @Transactional
     public GatheringCreateResponse createGathering(String email, GatheringCreateRequest createRequest) {
+
+        log.info("모임 내용 길이 : {}", createRequest.getGatheringContent().getBytes(StandardCharsets.UTF_8).length);
+
+        if (createRequest.getGatheringContent().getBytes(StandardCharsets.UTF_8).length > 1000) {
+            throw new IllegalArgumentException("내용이 DB 제한을 초과합니다.");
+        }
 
         // 0. 유저 검증
         User user = userService.checkUser(email);

--- a/src/main/java/com/manchui/domain/service/GatheringServiceImpl.java
+++ b/src/main/java/com/manchui/domain/service/GatheringServiceImpl.java
@@ -361,6 +361,27 @@ public class GatheringServiceImpl implements GatheringService {
         return new ClosedGatheringResponse(gatheringList.size(), closedGatheringList);
     }
 
+    /**
+     * 10. 유저가 요청한 마감된 모임 상세 내용 조회
+     * 작성자: 오예령
+     *
+     * @param email       유저 email
+     * @param gatheringId 모임 id
+     * @return 해당하는 모임 상세 내용 반환
+     */
+    @Override
+    public ClosedGatheringInfoResponse getClosedGatheringInfo(String email, Long gatheringId) {
+
+        User user = userService.checkUser(email);
+        Gathering gathering = gatheringReader.checkGatheringStatusIsClosed(gatheringId);
+
+        if (gathering.getUser() != user) throw new CustomException(PERMISSION_DENIED);
+
+        String gatheringImage = imageRepository.findByGatheringId(gatheringId).getFilePath();
+
+        return gathering.toClosedResponseDto(gatheringImage);
+    }
+
     // 참여 여부 판단
     private void handleExistingAttendance(Attendance attendance) {
 

--- a/src/main/java/com/manchui/global/exception/ErrorCode.java
+++ b/src/main/java/com/manchui/global/exception/ErrorCode.java
@@ -39,10 +39,10 @@ public enum ErrorCode {
     MUST_JOIN_IN(HttpStatus.BAD_REQUEST, "모임 주최자는 필수 참석입니다"),
 
     // review
-    ILLEGAL_GATHERING_STATUS(HttpStatus.BAD_REQUEST, "마감된 모임만 후기 등록이 가능합니다."),
+    ILLEGAL_GATHERING_STATUS(HttpStatus.BAD_REQUEST, "현재 마감된 모임이 아닙니다."),
     ALREADY_REVIEW_EXIST(HttpStatus.BAD_REQUEST, "참여한 모임에 대한 후기는 1회만 등록 가능합니다."),
     REVIEW_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 후기입니다."),
-    PERMISSION_DENIED(HttpStatus.BAD_REQUEST, "본인이 작성한 후기만 수정/삭제가 가능합니다."),
+    PERMISSION_DENIED(HttpStatus.BAD_REQUEST, "본인이 작성한 모임/후기만 관리 가능합니다."),
 
     // image
     ILLEGAL_EMPTY_FILE(HttpStatus.BAD_REQUEST, "이미지 파일은 필수 입력 값입니다."),

--- a/src/main/java/com/manchui/global/exception/ErrorCode.java
+++ b/src/main/java/com/manchui/global/exception/ErrorCode.java
@@ -23,6 +23,7 @@ public enum ErrorCode {
 
     // gathering
     ALREADY_USED_GROUP_NAME(HttpStatus.CONFLICT, "기존에 등록된 이름의 모임이 존재합니다."),
+    WRITTEN_GATHERING_NOT_EXIST(HttpStatus.OK, "생성한 모임 중 마감된 모임이 존재하지 않습니다."),
     ILLEGAL_MIN_USERS(HttpStatus.BAD_REQUEST, "최소 인원은 최대 인원보다 클 수 없습니다."),
     ILLEGAL_DUE_DATE(HttpStatus.BAD_REQUEST, "마감 기한은 최소 하루 이상이어야 합니다."),
     ILLEGAL_GATHERING_DATE(HttpStatus.BAD_REQUEST, "모임 날짜는 현재 시점으로부터 최소 24시간 이후여야 합니다."),

--- a/src/main/java/com/manchui/global/exception/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/manchui/global/exception/handler/GlobalExceptionHandler.java
@@ -34,6 +34,8 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(value = {IllegalArgumentException.class})
     public ResponseEntity<ErrorResponse> handleIllegalArgumentException(IllegalArgumentException ex) {
 
+        log.error("handleIllegalArgumentException : {}", ex.getMessage());
+
         ErrorResponse response = ErrorResponse.create()
                 .message(ex.getMessage())
                 .httpStatus(HttpStatus.BAD_REQUEST);

--- a/src/main/java/com/manchui/global/jwt/JWTFilter.java
+++ b/src/main/java/com/manchui/global/jwt/JWTFilter.java
@@ -36,16 +36,16 @@ public class JWTFilter extends OncePerRequestFilter {
         String requestMethod = request.getMethod();
 
         // 인증이 필요 없는 요청 처리
-        if ((requestUri.matches("^\\/api\\/auths\\/signup$") && requestMethod.equals("POST")) ||
-                (requestUri.matches("^\\/api\\/auths\\/check-name$") && requestMethod.equals("POST")) ||
-                (requestUri.matches("^\\/api\\/auths\\/signin$") && requestMethod.equals("POST")) ||
-                (requestUri.matches("^\\/api\\/reviews$") && requestMethod.equals("GET")) ||
+        if ((requestUri.matches("^/api/auths/signup$") && requestMethod.equals("POST")) ||
+                (requestUri.matches("^/api/auths/check-name$") && requestMethod.equals("POST")) ||
+                (requestUri.matches("^/api/auths/signin$") && requestMethod.equals("POST")) ||
+                (requestUri.matches("^/api/reviews$") && requestMethod.equals("GET")) ||
 
                 (requestUri.matches("^/swagger-ui(/.*)?$")) ||
                 (requestUri.matches("^/swagger-ui.html$")) ||
-                (requestUri.matches("^/v3/api-docs(?:/.*)?$"))) {
+                (requestUri.matches("^/v3/api-docs(?:/.*)?$")) ||
 
-                (requestUri.matches("^\\/api\\/auths\\/reissue$") && requestMethod.equals("POST"))) {
+                (requestUri.matches("^/api/auths/reissue$") && requestMethod.equals("POST"))) {
 
             filterChain.doFilter(request, response);
             return;


### PR DESCRIPTION
## #️⃣ Issue Number

<!--- ex) #이슈번호, #이슈번호 -->

#83 

## 📝 요약(Summary)

<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

- 모임 재생성 시 사용될 API 추가하였습니다.
- 마감된 모임의 이름을 조회할 수 있는 API와 해당 모임의 상세 내용을 조회하는 API 생성하였습니다.
- 예외 처리의 메세지를 좀 더 직관적이고 폭넓게 사용할 수 있도록 수정하였습니다. -> https://github.com/Manchui/Backend/commit/34478620e21667ab7cf9a29254ceaa44c2d4023d

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [X] 새로운 기능 추가
- [X] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [X] 주석 추가 및 수정
