### PR TITLE
[Fix] 파라미터로 받는 page값과 동일한 페이지의 정보를 반환하도록 수정

### DIFF
--- a/src/main/java/com/manchui/domain/controller/UserController.java
+++ b/src/main/java/com/manchui/domain/controller/UserController.java
@@ -13,10 +13,7 @@ import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.ModelAttribute;
-import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.UUID;
 

--- a/src/main/java/com/manchui/domain/service/UserService.java
+++ b/src/main/java/com/manchui/domain/service/UserService.java
@@ -7,6 +7,7 @@ import com.manchui.global.exception.CustomException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -90,9 +91,11 @@ public class UserService {
     //내가 작성한 모임 목록 조회
     public UserWrittenGatheringsResponse getWrittenGatheringList(String userEmail, Pageable pageable) {
 
+        PageRequest pageRequest = PageRequest.of(pageable.getPageNumber() - 1, pageable.getPageSize(), pageable.getSort());
+
         User user = userRepository.findByEmail(userEmail);
 
-        Page<Gathering> gatheringList = gatheringRepository.findByUserEquals(user, pageable);
+        Page<Gathering> gatheringList = gatheringRepository.findByUserEquals(user, pageRequest);
 
         //DTO에 맞게 변환
         Page<GatheringInfo> writtenGatheringList = gatheringList.map(m -> {
@@ -114,6 +117,8 @@ public class UserService {
     //사용자가 참여한 모임 목록 조회
     public UserParticipatedGatheringResponse getParticipatedGatheringList(String userEmail, Pageable pageable) {
 
+        PageRequest pageRequest = PageRequest.of(pageable.getPageNumber() - 1, pageable.getPageSize(), pageable.getSort());
+
         User user = userRepository.findByEmail(userEmail);
 
         //유저 모임 참여 엔티티 조회
@@ -129,7 +134,7 @@ public class UserService {
         }
 
         //참여한 모임 페이징 조회
-        Page<Gathering> gatheringList = gatheringRepository.findByIdIn(gatheringIdList, pageable);
+        Page<Gathering> gatheringList = gatheringRepository.findByIdIn(gatheringIdList, pageRequest);
 
         //GatheringInfo DTO로 변환
         Page<GatheringInfo> participatedGatheringList = gatheringList.map(m -> {
@@ -150,9 +155,11 @@ public class UserService {
     //내가 작성한 목록 조회
     public UserWrittenReviewsResponse getWrittenReviews(String userEmail, Pageable pageable) {
 
+        PageRequest pageRequest = PageRequest.of(pageable.getPageNumber() - 1, pageable.getPageSize(), pageable.getSort());
+
         User user = userRepository.findByEmail(userEmail);
         //리뷰 페이징 조회
-        Page<Review> reviews = reviewRepository.findByUser(user, pageable);
+        Page<Review> reviews = reviewRepository.findByUser(user, pageRequest);
         //사용자가 작성한 리뷰정보 DTO로 매핑
         Page<WrittenReviewInfo> writtenReviewInfos = reviews.map(m -> {
 
@@ -169,6 +176,8 @@ public class UserService {
 
     //리뷰 작성 가능한 모임 목록 조회
     public UserReviewableGatheringsResponse getReviewableGatherings(String userEmail, Pageable pageable) {
+
+        PageRequest pageRequest = PageRequest.of(pageable.getPageNumber() - 1, pageable.getPageSize(), pageable.getSort());
 
         User user = userRepository.findByEmail(userEmail);
         //참가 취소하지 않은 Attendance 조회
@@ -208,7 +217,7 @@ public class UserService {
             }
         }
         //리뷰 작성한 모임 페이징 조회
-        Page<Gathering> reviewableGatheringInfos = gatheringRepository.findByIdIn(reviewableGatheringIds, pageable);
+        Page<Gathering> reviewableGatheringInfos = gatheringRepository.findByIdIn(reviewableGatheringIds, pageRequest);
 
         //ReviewableGatheringInfo DTO에 맞게 변환
         Page<ReviewableGatheringInfo> map = reviewableGatheringInfos.map(m -> {


### PR DESCRIPTION
## #️⃣ Issue Number

<!--- ex) #이슈번호, #이슈번호 -->
#86 

## 📝 요약(Summary)

<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
- 이전에 파라미터로 page=0의 값을 받는 경우 첫번째 페이지의 정보를 반환했던것을 page=1의 값을 받는 경우 첫버째 페이지의 정보를 반환하도록 수정하였습니다.

## 🛠️ PR 유형

어떤 변경 사항이 있나요?
- [X] 버그 수정
