### PR TITLE
[Fix] 로그아웃시 refresh토큰 쿠키 만료 기능 수정

### DIFF
--- a/src/main/java/com/manchui/global/jwt/CustomLogoutFilter.java
+++ b/src/main/java/com/manchui/global/jwt/CustomLogoutFilter.java
@@ -17,6 +17,8 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
 import org.springframework.web.filter.GenericFilterBean;
 
 import java.io.IOException;
@@ -57,11 +59,8 @@ public class CustomLogoutFilter extends GenericFilterBean {
 
 
         //Refresh 토큰 쿠키 만료
-        Cookie cookie = new Cookie("refresh", null);
-        cookie.setMaxAge(0);
-        cookie.setPath("/");
+        setResponseCookie(response, "refresh", null);
 
-        response.addCookie(cookie);
         response.setStatus(HttpServletResponse.SC_OK);
         response.setContentType("application/json");
         response.setCharacterEncoding("UTF-8");
@@ -73,6 +72,17 @@ public class CustomLogoutFilter extends GenericFilterBean {
                 "}";
 
         response.getWriter().write(jsonResponse);
+    }
+
+    private void setResponseCookie(HttpServletResponse response, String key, String value) {
+        ResponseCookie cookie = ResponseCookie.from(key, value)
+                .maxAge(0)
+                .sameSite("None")
+                .secure(true)
+                .httpOnly(true)
+                .path("/")
+                .build();
+        response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
     }
 
     private void validateRefreshToken(HttpServletRequest request, HttpServletResponse response, String refresh) {


### PR DESCRIPTION
## #️⃣ Issue Number

<!--- ex) #이슈번호, #이슈번호 -->
#94 

## 📝 요약(Summary)

<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
로그아웃시 refresh토큰의 값을 null과 만료시간을 0으로해서 반환하도록 되어있었는데 프론트단에서 로그아웃 전에 가지고 있던 refresh토큰과 로그아웃시 전달받는 null값과 만료시간이 0인 refresh토큰을 두개 모두 가지고 있는 오류가 발생하였습니다.
다른 도메인 요청과 https에서 쿠키를 교환하게 하기 위해서 SameSite: None, Secure을 활성화 해주어서 오류를 해결했습니다.

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [X] 버그 수정