### PR TITLE
[Feat] 사용자가 속한 채팅방 목록 조회 기능 구현

### DIFF
--- a/src/main/java/com/manchui/domain/controller/ChatController.java
+++ b/src/main/java/com/manchui/domain/controller/ChatController.java
@@ -1,10 +1,7 @@
 package com.manchui.domain.controller;
 
 import com.manchui.domain.dto.CustomUserDetails;
-import com.manchui.domain.dto.chat.ChatMessageRequest;
-import com.manchui.domain.dto.chat.ChatMessageResponse;
-import com.manchui.domain.dto.chat.ChatMessageSliceResponse;
-import com.manchui.domain.dto.chat.ChatRoomUserListResponse;
+import com.manchui.domain.dto.chat.*;
 import com.manchui.domain.service.ChatMessageService;
 import com.manchui.domain.service.ChatRoomService;
 import com.manchui.global.response.SuccessResponse;
@@ -63,5 +60,11 @@ public class ChatController {
         ChatRoomUserListResponse response = chatRoomService.chatRoomUserList(roomId);
 
         return ResponseEntity.ok(SuccessResponse.successWithData(response));
+    }
+
+    @GetMapping("/api/chat/room/list")
+    public ResponseEntity<SuccessResponse<ChatRoomListResponse>> chatRoomList(@AuthenticationPrincipal CustomUserDetails customUserDetails) {
+
+        return ResponseEntity.ok().body(SuccessResponse.successWithData(chatRoomService.chatRoomList(customUserDetails)));
     }
 }

--- a/src/main/java/com/manchui/domain/dto/chat/ChatRoomListDetail.java
+++ b/src/main/java/com/manchui/domain/dto/chat/ChatRoomListDetail.java
@@ -1,0 +1,18 @@
+package com.manchui.domain.dto.chat;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+public class ChatRoomListDetail {
+
+    private String roomId;
+    private String image;
+    private String chatRoomTitle;
+    private int userNum;
+    private LocalDateTime lastMessageTime;
+    private String lastMessage;
+}

--- a/src/main/java/com/manchui/domain/dto/chat/ChatRoomListResponse.java
+++ b/src/main/java/com/manchui/domain/dto/chat/ChatRoomListResponse.java
@@ -1,0 +1,13 @@
+package com.manchui.domain.dto.chat;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class ChatRoomListResponse {
+
+    List<ChatRoomListDetail> cHatRoomListDetailList;
+}
+

--- a/src/main/java/com/manchui/domain/entity/ChatRoomUser.java
+++ b/src/main/java/com/manchui/domain/entity/ChatRoomUser.java
@@ -1,5 +1,6 @@
 package com.manchui.domain.entity;
 
+import com.manchui.global.entity.Timestamped;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -8,7 +9,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class ChatRoomUser {
+public class ChatRoomUser extends Timestamped {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/manchui/domain/repository/ChatRoomUserRepository.java
+++ b/src/main/java/com/manchui/domain/repository/ChatRoomUserRepository.java
@@ -14,4 +14,6 @@ public interface ChatRoomUserRepository extends JpaRepository<ChatRoomUser, Long
     List<ChatRoomUser> findByChatRoomEquals(ChatRoom chatRoom);
 
     Optional<ChatRoomUser> findByUserEqualsAndChatRoomEquals(User user, ChatRoom chatRoom);
+
+    List<ChatRoomUser> findByUser(User user);
 }

--- a/src/main/java/com/manchui/domain/repository/GatheringRepository.java
+++ b/src/main/java/com/manchui/domain/repository/GatheringRepository.java
@@ -1,5 +1,6 @@
 package com.manchui.domain.repository;
 
+import com.manchui.domain.entity.ChatRoom;
 import com.manchui.domain.entity.Gathering;
 import com.manchui.domain.entity.User;
 import com.manchui.domain.repository.querydsl.GatheringCursorQueryDsl;
@@ -21,4 +22,5 @@ public interface GatheringRepository extends JpaRepository<Gathering, Long>, Gat
 
     List<Gathering> findByUserAndIsClosedAndIsCanceled(User user, boolean isClosed, boolean isCanceled);
 
+    Optional<Gathering> findByChatRoomEquals(ChatRoom chatRoom);
 }

--- a/src/main/java/com/manchui/domain/repository/mongodb/ChatMessageRepository.java
+++ b/src/main/java/com/manchui/domain/repository/mongodb/ChatMessageRepository.java
@@ -5,6 +5,8 @@ import org.bson.types.ObjectId;
 import org.springframework.data.mongodb.repository.Query;
 import org.springframework.data.mongodb.repository.ReactiveMongoRepository;
 import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
 
 public interface ChatMessageRepository extends ReactiveMongoRepository<ChatMessage, String> {
 
@@ -12,4 +14,6 @@ public interface ChatMessageRepository extends ReactiveMongoRepository<ChatMessa
 
     @Query(value = "{ 'roomId': ?0, '_id': { $lt: ?1 } }", sort = "{ '_id': -1 }")
     Flux<ChatMessage> findByRoomIdAndIdLessThanOrderByIdDesc(String roomId, ObjectId lastMessageId);
+
+    Mono<ChatMessage> findFirstByRoomIdOrderByCreatedAtDesc(String roomId);
 }

--- a/src/main/java/com/manchui/domain/service/ChatRoomService.java
+++ b/src/main/java/com/manchui/domain/service/ChatRoomService.java
@@ -1,14 +1,21 @@
 package com.manchui.domain.service;
 
+import com.manchui.domain.dto.CustomUserDetails;
 import com.manchui.domain.dto.UserInfo;
+import com.manchui.domain.dto.chat.ChatRoomListDetail;
+import com.manchui.domain.dto.chat.ChatRoomListResponse;
 import com.manchui.domain.dto.chat.ChatRoomUserListResponse;
-import com.manchui.domain.entity.ChatRoom;
-import com.manchui.domain.entity.ChatRoomUser;
-import com.manchui.domain.repository.ChatRoomRepository;
-import com.manchui.domain.repository.ChatRoomUserRepository;
+import com.manchui.domain.entity.*;
+import com.manchui.domain.entity.mongodb.ChatMessage;
+import com.manchui.domain.repository.*;
+import com.manchui.domain.repository.mongodb.ChatMessageRepository;
+import com.manchui.global.exception.CustomException;
+import com.manchui.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+
+import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -18,6 +25,10 @@ public class ChatRoomService {
 
     private final ChatRoomUserRepository chatRoomUserRepository;
     private final ChatRoomRepository chatRoomRepository;
+    private final UserRepository userRepository;
+    private final GatheringRepository gatheringRepository;
+    private final ImageRepository imageRepository;
+    private final ChatMessageRepository chatMessageRepository;
 
     // 채팅방 회원 목록 조회
     public ChatRoomUserListResponse chatRoomUserList(String roomId) {
@@ -32,5 +43,29 @@ public class ChatRoomService {
         )).collect(Collectors.toList());
 
         return new ChatRoomUserListResponse(userInfoList);
+    }
+
+    // 사용자가 속한 채팅방 목록 조회
+    public ChatRoomListResponse chatRoomList(CustomUserDetails customUserDetails) {
+        // 회원 조회
+        String userEmail = customUserDetails.getUsername();
+        User user = userRepository.findByEmail(userEmail);
+        // 사용자가 속하 ChatRoomUser 조회
+        List<ChatRoomUser> chatRoomUsers = chatRoomUserRepository.findByUser(user);
+        // ChatRoomUser -> DTO(ChatRoomListDetail) 변환
+        List<ChatRoomListDetail> chatRoomListDetails = chatRoomUsers.stream().map((m -> {
+            ChatRoom chatRoom = m.getChatRoom();
+            Gathering gathering = gatheringRepository.findByChatRoomEquals(chatRoom).orElseThrow(
+                    () -> new CustomException(ErrorCode.GATHERING_NOT_FOUND));
+
+            Image image = imageRepository.findByGatheringId(gathering.getId());
+            List<ChatRoomUser> chatRoomEquals = chatRoomUserRepository.findByChatRoomEquals(chatRoom);
+
+            ChatMessage lastMessage = chatMessageRepository.findFirstByRoomIdOrderByCreatedAtDesc(chatRoom.getRoomId()).block();
+            return new ChatRoomListDetail(m.getChatRoom().getRoomId(), image.getFilePath(), gathering.getGroupName(),
+                    chatRoomEquals.size(), lastMessage.getCreatedAt(), lastMessage.getMessage());
+        })).sorted(Comparator.comparing(ChatRoomListDetail::getLastMessageTime).reversed()).collect(Collectors.toList());
+
+        return new ChatRoomListResponse(chatRoomListDetails);
     }
 }


### PR DESCRIPTION
## #️⃣ Issue Number

<!--- ex) #이슈번호, #이슈번호 -->
#108 

## 📝 요약(Summary)

<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
- 4037e34: 사용자가 속한 채팅방 목록 조회를 구현 하였습니다. 채팅방 목록 조회시 사용자가 볼수있는 항목으로 채팅방 목록 조회시 게시글 사진, 게시글 제목, 채팅방 인원수, 마지막 채팅 시간, 마지막 채팅을 DTO에 맞게 반환하도록 하였습니다. 가장 최근에 채팅이 오고간 채팅방을 가장 먼저 보이도록 하였습니다.

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [X] 새로운 기능 추가
