### PR TITLE
[Fix] 무한 스크롤을 위한 nextCursor 추가

### DIFF
--- a/src/main/java/com/manchui/domain/dto/chat/ChatMessageSliceResponse.java
+++ b/src/main/java/com/manchui/domain/dto/chat/ChatMessageSliceResponse.java
@@ -11,4 +11,5 @@ public class ChatMessageSliceResponse {
 
     private List<ChatMessageResponse> chatMessageResponseList;
     private Boolean hasNext;
+    private String nextCursor;
 }

--- a/src/main/java/com/manchui/domain/service/ChatMessageService.java
+++ b/src/main/java/com/manchui/domain/service/ChatMessageService.java
@@ -91,6 +91,10 @@ public class ChatMessageService {
                 .map(messages -> {
                     // limit + 1개 중 실제 limit개만 표시하고, 나머지 1개로 hasNext 판단
                     boolean hasNext = messages.size() > limit;
+                    String nextCursor = null;
+                    if(hasNext){
+                        nextCursor = messages.get(limit - 1).get_id();
+                    }
                     List<ChatMessageResponse> content = messages.stream().limit(limit)
                             .map(chatMessage ->
                                     new ChatMessageResponse(
@@ -101,7 +105,7 @@ public class ChatMessageService {
                                             chatMessage.getCreatedAt()
                                     )).collect(Collectors.toList());
 
-                    return new ChatMessageSliceResponse(content, hasNext);
+                    return new ChatMessageSliceResponse(content, hasNext, nextCursor);
                 });
     }
 }


### PR DESCRIPTION
## #️⃣ Issue Number

<!--- ex) #이슈번호, #이슈번호 -->
#110 

## 📝 요약(Summary)

<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
채팅 목록 조회시 무한 스크롤을 위한 nextCursor의 값을 추가하기 위해 DTO의 nextCursor값을 추가해줬고 nextCursor 값에는 마지막 채팅 메시지의 ID의 값으로 하였습니다.

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [X] 버그 수정
