### PR TITLE
[Refactor] 모임 카테고리 필터링 수정

### DIFF
--- a/src/main/java/com/manchui/domain/entity/Category.java
+++ b/src/main/java/com/manchui/domain/entity/Category.java
@@ -1,0 +1,31 @@
+package com.manchui.domain.entity;
+
+public enum Category {
+    ALL("전체", "all"),
+    DEVELOP("개발", "develop"),
+    HEALTH("운동", "health"),
+    MOVIE("영화", "movie"),
+    STUDY("공부", "study"),
+    CULTURE_ART("문화/예술", "cultureart"),
+    GAME("게임", "game"),
+    TRAVEL("여행", "travel"),
+    FOOD("맛집", "food"),
+    MUSIC("음악", "music");
+
+    private final String korean;
+    private final String english;
+
+    Category(String korean, String english) {
+        this.korean = korean;
+        this.english = english;
+    }
+
+    public static String toKorean(String english) {
+        for (Category category : values()) {
+            if (category.english.equalsIgnoreCase(english)) {
+                return category.korean;
+            }
+        }
+        throw new IllegalArgumentException("Invalid category: " + english);
+    }
+}

--- a/src/main/java/com/manchui/domain/repository/querydsl/GatheringCursorQueryDslImpl.java
+++ b/src/main/java/com/manchui/domain/repository/querydsl/GatheringCursorQueryDslImpl.java
@@ -2,6 +2,7 @@ package com.manchui.domain.repository.querydsl;
 
 import com.manchui.domain.dto.gathering.GatheringCursorPagingResponse;
 import com.manchui.domain.dto.gathering.GatheringListResponse;
+import com.manchui.domain.entity.Category;
 import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.types.ConstructorExpression;
 import com.querydsl.core.types.Projections;
@@ -168,8 +169,9 @@ public class GatheringCursorQueryDslImpl implements GatheringCursorQueryDsl {
             condition = condition.and(gathering.gatheringDate.between(start.atStartOfDay(), end.atTime(23, 59, 59)));
         }
 
-        if (category != null && !category.isEmpty()) {
-            condition = condition.and(gathering.category.eq(category));
+        if (category != null && !category.isEmpty() && !category.equalsIgnoreCase("all")) {
+            String koreanCategory = Category.toKorean(category);
+            condition = condition.and(gathering.category.eq(koreanCategory));
         }
 
         return condition;

--- a/src/main/java/com/manchui/domain/repository/querydsl/GatheringQueryDslImpl.java
+++ b/src/main/java/com/manchui/domain/repository/querydsl/GatheringQueryDslImpl.java
@@ -1,6 +1,7 @@
 package com.manchui.domain.repository.querydsl;
 
 import com.manchui.domain.dto.gathering.GatheringListResponse;
+import com.manchui.domain.entity.Category;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.impl.JPAQuery;
@@ -96,8 +97,9 @@ public class GatheringQueryDslImpl implements GatheringQueryDsl {
             queryBuilder.where(gathering.gatheringDate.between(start.atStartOfDay(), end.atTime(23, 59, 59)));
         }
 
-        if (StringUtils.hasText(category)) {
-            queryBuilder.where(gathering.category.eq(category));
+        if (StringUtils.hasText(category) && !category.equalsIgnoreCase("all")) {
+            String koreanCategory = Category.toKorean(category);
+            queryBuilder.where(gathering.category.eq(koreanCategory));
         }
 
         // 정렬 조건 적용


### PR DESCRIPTION
## #️⃣ Issue Number

#104 

<br>

## 📝 요약(Summary)

- 모임 목록 조회 시 카테고리 필터링 방법을 기존 한글에서 영어로 수정하였습니다. 
- 전체 - all, 개발 - develop, 운동 - health, 영화 - movie, 공부 - study, 문화/예술 - cultureart, 게임 - game, 여행 - travel, 맛집 - food, 음악 - music
- 카테고리 관리를 위한 enum 클래스를 생성하여 영어를 한글로 매핑하여 기존 저장된 데이터와 비교할 수 있도록 하였습니다.

<br>

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [X] 코드 리팩토링

