### PR TITLE
[Fix] 채팅창 입장 이후의 채팅 메시지가 보이도록 수정

### DIFF
--- a/src/main/java/com/manchui/domain/service/ChatMessageService.java
+++ b/src/main/java/com/manchui/domain/service/ChatMessageService.java
@@ -85,10 +85,13 @@ public class ChatMessageService {
 
                         if (chatRoomUser.isEmpty()) {
                             // 채팅방 첫입장
-                            chatRoomUserUpdatedAt = chatRoomUserRepository.save(new ChatRoomUser(user, chatRoom)).getUser().getUpdatedAt();
-                            chatMessageRepository.save(new ChatMessage(roomId, ChatMessageType.ENTER, user.getName(), user.getName() + " 님이 입장 하셨습니다.", LocalDateTime.now())).block();
+                            ChatRoomUser savedChatRoomUser = chatRoomUserRepository.save(new ChatRoomUser(user, chatRoom));
+                            chatRoomUserRepository.flush();
+                            chatRoomUserUpdatedAt = savedChatRoomUser.getUpdatedAt();
+
+                            chatMessageRepository.save(new ChatMessage(roomId, ChatMessageType.ENTER, user.getName(), user.getName() + " 님이 입장 하셨습니다.", chatRoomUserUpdatedAt)).block();
                             rabbitTemplate.convertAndSend("chat.exchange", "room." + roomId, new ChatMessageResponse(
-                                    user.getName(), user.getName() + " 님이 입장 하셨습니다.", ChatMessageType.ENTER, LocalDateTime.now()));
+                                    user.getName(), user.getName() + " 님이 입장 하셨습니다.", ChatMessageType.ENTER, chatRoomUserUpdatedAt));
                         }else if(chatRoomUser.get().getDeletedAt() != null){
                             // 채팅방 재입장
                             chatRoomUser.get().restore();


### PR DESCRIPTION
## #️⃣ Issue Number

<!--- ex) #이슈번호, #이슈번호 -->

## 📝 요약(Summary)
#117 

<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
- 재입장 시 저장되는 '입장 메시지'의 타임스탬프가, 실제 DB에 저장된 업데이트 시각과 미세하게 달라서, "입장 시간 이후" 조건으로 메시지가 조회되지 않는 현상이 발생하였습니다.
- 첫 입장시 새로운 chatRoomUser를 저장후 flush를 영속성 컨텍스트에 있는 모든 변경사항을 즉시 DB에 동기화 하여 해결하였습니다.

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [X] 버그 수정
