### PR TITLE
[Fix] 채팅 무한스크롤 조회 수정

### DIFF
--- a/src/main/java/com/manchui/domain/chat/repository/mongodb/ChatMessageRepository.java
+++ b/src/main/java/com/manchui/domain/chat/repository/mongodb/ChatMessageRepository.java
@@ -13,7 +13,7 @@ public interface ChatMessageRepository extends ReactiveMongoRepository<ChatMessa
 
     Flux<ChatMessage> findByRoomIdAndCreatedAtGreaterThanEqualOrderByCreatedAtDesc(String roomId, LocalDateTime createdAt);
 
-    @Query(value = "{ 'roomId': ?0, '_id': { $lt: ?1 }, 'createdAt': { $lt: ?2 } }", sort = "{ '_id': -1 }")
+    @Query(value = "{ 'roomId': ?0, '_id': { $lt: ?1 }, 'createdAt': { $gte: ?2 } }", sort = "{ '_id': -1 }")
     Flux<ChatMessage> findByRoomIdAndIdLessThanAndCreatedAtGreaterThanEqualOrderByIdDesc(String roomId, ObjectId lastMessageId, LocalDateTime createdAt);
 
     Mono<ChatMessage> findFirstByRoomIdOrderByCreatedAtDesc(String roomId);


### PR DESCRIPTION
## #️⃣ Issue Number

<!--- ex) #이슈번호, #이슈번호 -->
#124 

## 📝 요약(Summary)

<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
무한스크롤 채팅 목록 조회시 잘못된 채팅 목록 데이터를 반환하는것을 수정했습니다.
채팅 목록을 반환하는 조건 중 createdAt의 조건을 lt -> gte로 변경하여 문제를 해결했습니다.

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [X] 버그 수정
